### PR TITLE
chore: Group SAP Cloud SDK dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,6 @@ updates:
       # We only want to do major node updates on purpose, so don't create dependabot PRs for major versions
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
+    groups:
+      sap-cloud-sdk:
+        patterns: '@sap-cloud-sdk/*'


### PR DESCRIPTION
Group dependency updates to make sure, that all SDK dependencies are always updated together.