### PR TITLE
chore: Fix nightly canary release

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -47,6 +47,6 @@ jobs:
           pnpm changeset pre enter ${date}
           pnpm changeset version
           pnpm changeset pre exit
-          pnpm changeset publish --tag ${{ inputs.tag }}
+          pnpm changeset publish --tag ${{ github.event_name == 'schedule' && 'canary' || inputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}


### PR DESCRIPTION
This should fix the nightly canary release.
@jjtang1985 should we add the check, whether anything was changed since the last release now or later?