### PR TITLE
chore: Refactor client test structure and generation script

### DIFF
--- a/packages/ai-core/package.json
+++ b/packages/ai-core/package.json
@@ -21,7 +21,7 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "eslint . && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -c",
     "lint:fix": "eslint . --fix && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --log-level error",
-    "generate": "openapi-generator --generateESM  --overwrite --input ./src/spec/AI_CORE_API.yaml --outputDir ./src/client && pnpm lint:fix"
+    "generate": "openapi-generator --generateESM --clearOutputDir -i ./src/spec/AI_CORE_API.yaml -o ./src/client && pnpm lint:fix"
   },
   "dependencies": {
     "@sap-cloud-sdk/openapi": "^3.18.0"

--- a/packages/ai-core/src/tests/artifact-api.test.ts
+++ b/packages/ai-core/src/tests/artifact-api.test.ts
@@ -3,9 +3,9 @@ import { HttpDestination } from '@sap-cloud-sdk/connectivity';
 import {
   AiArtifactCreationResponse,
   AiArtifactList,
-  AiArtifactPostData
-} from '../client/AI_CORE_API/schema/index.js';
-import { ArtifactApi } from '../client/AI_CORE_API/artifact-api.js';
+  AiArtifactPostData,
+  ArtifactApi
+} from '../client/AI_CORE_API/index.js';
 
 describe('artifact', () => {
   const destination: HttpDestination = {

--- a/packages/ai-core/src/tests/artifact-api.test.ts
+++ b/packages/ai-core/src/tests/artifact-api.test.ts
@@ -4,8 +4,8 @@ import {
   AiArtifactCreationResponse,
   AiArtifactList,
   AiArtifactPostData
-} from './schema/index.js';
-import { ArtifactApi } from './artifact-api.js';
+} from '../client/AI_CORE_API/schema/index.js';
+import { ArtifactApi } from '../client/AI_CORE_API/artifact-api.js';
 
 describe('artifact', () => {
   const destination: HttpDestination = {
@@ -68,7 +68,7 @@ describe('artifact', () => {
         'Content-Type': 'application/json'
       });
 
-    const AiArtifactPostData: AiArtifactPostData = {
+    const aiArtifactPostData: AiArtifactPostData = {
       description: 'dataset for training test',
       kind: 'dataset',
       name: 'training-test-data',
@@ -77,7 +77,7 @@ describe('artifact', () => {
     };
 
     const result: AiArtifactCreationResponse = await ArtifactApi.artifactCreate(
-      AiArtifactPostData,
+      aiArtifactPostData,
       { 'AI-Resource-Group': 'default' }
     ).execute(destination);
 

--- a/packages/ai-core/src/tests/configuration-api.test.ts
+++ b/packages/ai-core/src/tests/configuration-api.test.ts
@@ -3,9 +3,9 @@ import { HttpDestination } from '@sap-cloud-sdk/connectivity';
 import {
   AiConfigurationBaseData,
   AiConfigurationCreationResponse,
-  AiConfigurationList
-} from '../client/AI_CORE_API/schema/index.js';
-import { ConfigurationApi } from '../client/AI_CORE_API/configuration-api.js';
+  AiConfigurationList,
+  ConfigurationApi
+} from '../client/AI_CORE_API/index.js';
 
 describe('configuration', () => {
   const destination: HttpDestination = {

--- a/packages/ai-core/src/tests/configuration-api.test.ts
+++ b/packages/ai-core/src/tests/configuration-api.test.ts
@@ -4,8 +4,8 @@ import {
   AiConfigurationBaseData,
   AiConfigurationCreationResponse,
   AiConfigurationList
-} from './schema/index.js';
-import { ConfigurationApi } from './configuration-api.js';
+} from '../client/AI_CORE_API/schema/index.js';
+import { ConfigurationApi } from '../client/AI_CORE_API/configuration-api.js';
 
 describe('configuration', () => {
   const destination: HttpDestination = {

--- a/packages/ai-core/src/tests/deployment-api.test.ts
+++ b/packages/ai-core/src/tests/deployment-api.test.ts
@@ -8,8 +8,8 @@ import {
   AiDeploymentModificationRequest,
   AiDeploymentModificationResponse,
   AiDeploymentTargetStatus
-} from './schema/index.js';
-import { DeploymentApi } from './deployment-api.js';
+} from '../client/AI_CORE_API/schema/index.js';
+import { DeploymentApi } from '../client/AI_CORE_API/deployment-api.js';
 
 describe('deployment', () => {
   const destination: HttpDestination = {

--- a/packages/ai-core/src/tests/deployment-api.test.ts
+++ b/packages/ai-core/src/tests/deployment-api.test.ts
@@ -7,9 +7,9 @@ import {
   AiDeploymentList,
   AiDeploymentModificationRequest,
   AiDeploymentModificationResponse,
-  AiDeploymentTargetStatus
-} from '../client/AI_CORE_API/schema/index.js';
-import { DeploymentApi } from '../client/AI_CORE_API/deployment-api.js';
+  AiDeploymentTargetStatus,
+  DeploymentApi
+} from '../client/AI_CORE_API/index.js';
 
 describe('deployment', () => {
   const destination: HttpDestination = {

--- a/packages/ai-core/src/tests/execution-api.test.ts
+++ b/packages/ai-core/src/tests/execution-api.test.ts
@@ -4,8 +4,8 @@ import {
   AiEnactmentCreationRequest,
   AiExecutionCreationResponse,
   AiExecutionList
-} from './schema/index.js';
-import { ExecutionApi } from './execution-api.js';
+} from '../client/AI_CORE_API/schema/index.js';
+import { ExecutionApi } from '../client/AI_CORE_API/execution-api.js';
 
 describe('execution', () => {
   const destination: HttpDestination = {

--- a/packages/ai-core/src/tests/execution-api.test.ts
+++ b/packages/ai-core/src/tests/execution-api.test.ts
@@ -3,9 +3,9 @@ import { HttpDestination } from '@sap-cloud-sdk/connectivity';
 import {
   AiEnactmentCreationRequest,
   AiExecutionCreationResponse,
-  AiExecutionList
-} from '../client/AI_CORE_API/schema/index.js';
-import { ExecutionApi } from '../client/AI_CORE_API/execution-api.js';
+  AiExecutionList,
+  ExecutionApi
+} from '../client/AI_CORE_API/index.js';
 
 describe('execution', () => {
   const destination: HttpDestination = {

--- a/packages/ai-core/src/tests/scenario-api.test.ts
+++ b/packages/ai-core/src/tests/scenario-api.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock';
 import { HttpDestination } from '@sap-cloud-sdk/connectivity';
-import { AiScenarioList } from './schema/index.js';
-import { ScenarioApi } from './scenario-api.js';
+import { ScenarioApi } from '../client/AI_CORE_API/scenario-api.js';
+import { AiScenarioList } from '../client/AI_CORE_API/schema/index.js';
 
 describe('scenario', () => {
   const destination: HttpDestination = {

--- a/packages/ai-core/src/tests/scenario-api.test.ts
+++ b/packages/ai-core/src/tests/scenario-api.test.ts
@@ -1,7 +1,6 @@
 import nock from 'nock';
 import { HttpDestination } from '@sap-cloud-sdk/connectivity';
-import { ScenarioApi } from '../client/AI_CORE_API/scenario-api.js';
-import { AiScenarioList } from '../client/AI_CORE_API/schema/index.js';
+import { ScenarioApi, AiScenarioList } from '../client/AI_CORE_API/index.js';
 
 describe('scenario', () => {
   const destination: HttpDestination = {

--- a/packages/gen-ai-hub/package.json
+++ b/packages/gen-ai-hub/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint . && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -c",
     "lint:fix": "eslint . --fix && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --log-level error",
     "generate": "pnpm generate:orchestration",
-    "generate:orchestration": "openapi-generator --overwrite --generateESM -i ./src/orchestration/spec/api.yaml -o ./src/orchestration/client && pnpm lint:fix"
+    "generate:orchestration": "openapi-generator --generateESM --clearOutputDir -i ./src/orchestration/spec/api.yaml -o ./src/orchestration/client && pnpm lint:fix"
   },
   "dependencies": {
     "@sap-ai-sdk/core": "workspace:^",


### PR DESCRIPTION
While re-generating our clients, we noticed that deprecated files are not automatically removed, existing ones are only overwritten.
As we want to get rid of any manual steps during and after generation, we need to clear the output directory in the future.

With this PR, we switch from overwriting to clearing the output directory.
To keep our tests, they are moved to a separate testing directory. 