### PR TITLE
chore: Simplify canary release config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@sap-ai-sdk/sample-code", "@sap-ai-sdk/e2e-tests", "@sap-ai-sdk/type-tests"]
+  "ignore": []
 }

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -34,9 +34,7 @@ jobs:
           rm -f .changeset/*.md || true
           cat <<EOT >> .changeset/canary-release-changeset.md
           ---
-          '@sap-ai-sdk/ai-core': patch
           '@sap-ai-sdk/core': patch
-          '@sap-ai-sdk/gen-ai-hub': patch
           ---
 
           Canary release


### PR DESCRIPTION
This removes some of the config that I added previously:
1. Keep only one package in the dummy changelog for canary - due to the fixed versioning this is enough.
2. Do not ignore packages - all packages that should not be released have the private flag and this prevents them from being published.

This means for as long as we keep fixed versioning there is not need to adjust the config when changing the package structure.