### PR TITLE
chore: Add filter utility to improve discoverability

### DIFF
--- a/packages/gen-ai-hub/src/orchestration/orchestration-client.test.ts
+++ b/packages/gen-ai-hub/src/orchestration/orchestration-client.test.ts
@@ -12,7 +12,10 @@ import {
   GenAiHubClient,
   constructCompletionPostRequest
 } from './orchestration-client.js';
-import { azureContentFilter } from './orchestration-filter-utility.js';
+import {
+  azureContentFilter,
+  FilterUtility
+} from './orchestration-filter-utility.js';
 describe('GenAiHubClient', () => {
   const client = new GenAiHubClient();
   const deploymentConfiguration: BaseLlmParametersWithDeploymentId = {
@@ -78,7 +81,7 @@ describe('GenAiHubClient', () => {
       },
       filterConfig: {
         input: azureContentFilter({ Hate: 4, SelfHarm: 2 }),
-        output: azureContentFilter({ Sexual: 0, Violence: 4 })
+        output: FilterUtility.azureContentFilter({ Sexual: 0, Violence: 4 })
       }
     };
     const mockResponse = parseMockResponse<CompletionPostResponse>(

--- a/packages/gen-ai-hub/src/orchestration/orchestration-filter-utility.test.ts
+++ b/packages/gen-ai-hub/src/orchestration/orchestration-filter-utility.test.ts
@@ -3,7 +3,10 @@ import {
   FilteringModuleConfig
 } from './client/api/index.js';
 import { constructCompletionPostRequest } from './orchestration-client.js';
-import { azureContentFilter } from './orchestration-filter-utility.js';
+import {
+  azureContentFilter,
+  FilterUtility
+} from './orchestration-filter-utility.js';
 import { GenAiHubCompletionParameters } from './orchestration-types.js';
 
 describe('Filter utility', () => {
@@ -81,13 +84,13 @@ describe('Filter utility', () => {
 
   it('constructs filter configuration with both input and ouput', async () => {
     const filterConfig: FilteringModuleConfig = {
-      input: azureContentFilter({
+      input: FilterUtility.azureContentFilter({
         Hate: 4,
         SelfHarm: 0,
         Sexual: 2,
         Violence: 6
       }),
-      output: azureContentFilter({ Sexual: 2, Violence: 6 })
+      output: FilterUtility.azureContentFilter({ Sexual: 2, Violence: 6 })
     };
     const expectedFilterConfig: FilteringModuleConfig = {
       input: {

--- a/packages/gen-ai-hub/src/orchestration/orchestration-filter-utility.ts
+++ b/packages/gen-ai-hub/src/orchestration/orchestration-filter-utility.ts
@@ -20,3 +20,15 @@ export function azureContentFilter(
     ]
   };
 }
+
+/**
+ * Utilty providing convenience functions to create filtering configurations.
+ */
+export const FilterUtility = {
+  /**
+   * Convenience function to create Azure filters.
+   * @param filter - Filtering configuration for Azure filter. If skipped, the default Azure filter configuration is used.
+   * @returns An object with the Azure filtering configuration.
+   */
+  azureContentFilter
+};


### PR DESCRIPTION
This PR introduces `FilterUtility` to make new functionality being added to filter configuration like for e.g a new service provider discoverable.
Still choosing to retain the direct function usage (`azureContentFilter()`) as well because currently we only have one option and it shortens code.

Proposed state:
```Typescript
client.chatCompletion({
  deploymentConfiguration: { deploymentId: 'id' },
  llmConfig: {
    model_name: 'gpt-35-turbo-16k',
    model_params: { max_tokens: 50, temperature: 0.1 }
  },
  prompt: {
    template: [{ role: 'user', content: 'What is the capital of Germany?' }]
  },
  filterConfig: {
     //Both options are allowed
    input: FilterUtility.azureContentFilter({ Hate: 4, SelfHarm: 2 }), 
    output: azureContentFilter({ Sexual: 0, Violence: 6 })
  }
});
```