### PR TITLE
fix: Missing visibility of azureContentFilter

### DIFF
--- a/packages/gen-ai-hub/src/index.ts
+++ b/packages/gen-ai-hub/src/index.ts
@@ -6,6 +6,7 @@ export {
   OpenAiChatCompletionOutput
 } from './client/index.js';
 export {
+  azureContentFilter,
   GenAiHubClient,
   GenAiHubCompletionParameters,
   GenAiHubCompletionResponse,


### PR DESCRIPTION
This function is supposed to be used publicly, which needs to be added to the index file