### PR TITLE
chore: Adjust orchestration tests

### DIFF
--- a/packages/gen-ai-hub/src/orchestration/orchestration-client.test.ts
+++ b/packages/gen-ai-hub/src/orchestration/orchestration-client.test.ts
@@ -72,7 +72,10 @@ describe('GenAiHubClient', () => {
       },
       prompt: {
         template: [
-          { role: 'user', content: 'Create {number} paraphrases of {phrase}' }
+          {
+            role: 'user',
+            content: 'Create {{?number}} paraphrases of {{?phrase}}'
+          }
         ],
         template_params: { phrase: 'I hate you.', number: 3 }
       },
@@ -114,7 +117,10 @@ describe('GenAiHubClient', () => {
       },
       prompt: {
         template: [
-          { role: 'user', content: 'Create {number} paraphrases of {phrase}' }
+          {
+            role: 'user',
+            content: 'Create {{?number}} paraphrases of {{?phrase}}'
+          }
         ],
         template_params: { phrase: 'I hate you.', number: 3 }
       },

--- a/packages/gen-ai-hub/src/orchestration/orchestration-completion-post-request.test.ts
+++ b/packages/gen-ai-hub/src/orchestration/orchestration-completion-post-request.test.ts
@@ -46,6 +46,7 @@ describe('constructCompletionPostRequest()', () => {
     expect(completionPostRequest).toEqual(expectedCompletionPostRequest);
   });
 
+  // Todo: Adapt the test after Cloud SDK fix for: https://github.com/SAP/cloud-sdk-backlog/issues/1234
   it('with model configuration and empty template', async () => {
     genaihubCompletionParameters.prompt.template = [];
     const expectedCompletionPostRequest: CompletionPostRequest = {
@@ -262,6 +263,7 @@ describe('constructCompletionPostRequest()', () => {
     expect(completionPostRequest).toEqual(expectedCompletionPostRequest);
   });
 
+  // Todo: Adapt the test after Cloud SDK fix for: https://github.com/SAP/cloud-sdk-backlog/issues/1234
   it('with model configuration, prompt template empty filter configuration', async () => {
     genaihubCompletionParameters.filterConfig = {};
     const expectedCompletionPostRequest: CompletionPostRequest = {

--- a/packages/gen-ai-hub/src/orchestration/orchestration-completion-post-request.test.ts
+++ b/packages/gen-ai-hub/src/orchestration/orchestration-completion-post-request.test.ts
@@ -46,10 +46,33 @@ describe('constructCompletionPostRequest()', () => {
     expect(completionPostRequest).toEqual(expectedCompletionPostRequest);
   });
 
+  it('with model configuration and empty template', async () => {
+    genaihubCompletionParameters.prompt.template = [];
+    const expectedCompletionPostRequest: CompletionPostRequest = {
+      orchestration_config: {
+        module_configurations: {
+          templating_module_config: {
+            template: []
+          },
+          llm_module_config: {
+            model_name: 'gpt-35-turbo-16k',
+            model_params: { max_tokens: 50, temperature: 0.1 }
+          }
+        }
+      }
+    };
+    const completionPostRequest: CompletionPostRequest =
+      constructCompletionPostRequest(genaihubCompletionParameters);
+    expect(completionPostRequest).toEqual(expectedCompletionPostRequest);
+  });
+
   it('with model configuration, prompt template and template params', async () => {
     genaihubCompletionParameters.prompt = {
       template: [
-        { role: 'user', content: 'Create {number} paraphrases of {phrase}' }
+        {
+          role: 'user',
+          content: 'Create {{?number}} paraphrases of {{?phrase}}'
+        }
       ],
       template_params: { phrase: 'I hate you.', number: 3 }
     };
@@ -60,7 +83,7 @@ describe('constructCompletionPostRequest()', () => {
             template: [
               {
                 role: 'user',
-                content: 'Create {number} paraphrases of {phrase}'
+                content: 'Create {{?number}} paraphrases of {{?phrase}}'
               }
             ]
           },
@@ -71,6 +94,40 @@ describe('constructCompletionPostRequest()', () => {
         }
       },
       input_params: { phrase: 'I hate you.', number: 3 }
+    };
+    const completionPostRequest: CompletionPostRequest =
+      constructCompletionPostRequest(genaihubCompletionParameters);
+    expect(completionPostRequest).toEqual(expectedCompletionPostRequest);
+  });
+
+  it('with model configuration, prompt template and empty template params', async () => {
+    genaihubCompletionParameters.prompt = {
+      template: [
+        {
+          role: 'user',
+          content: 'Create {{?number}} paraphrases of {{?phrase}}'
+        }
+      ],
+      template_params: {}
+    };
+    const expectedCompletionPostRequest: CompletionPostRequest = {
+      orchestration_config: {
+        module_configurations: {
+          templating_module_config: {
+            template: [
+              {
+                role: 'user',
+                content: 'Create {{?number}} paraphrases of {{?phrase}}'
+              }
+            ]
+          },
+          llm_module_config: {
+            model_name: 'gpt-35-turbo-16k',
+            model_params: { max_tokens: 50, temperature: 0.1 }
+          }
+        }
+      },
+      input_params: {}
     };
     const completionPostRequest: CompletionPostRequest =
       constructCompletionPostRequest(genaihubCompletionParameters);

--- a/tests/e2e-tests/src/orchestration.test.ts
+++ b/tests/e2e-tests/src/orchestration.test.ts
@@ -20,7 +20,18 @@ describe('orchestration', () => {
         model_params: { max_tokens: 50, temperature: 0.1 }
       },
       prompt: {
-        template: [{ role: 'user', content: 'Hello!' }]
+        template: [
+          {
+            role: 'user',
+            content:
+              'Create {{?number}} of paraphrases of {{?phrase1}} and {{?phrase2}}'
+          }
+        ],
+        template_params: {
+          number: '3',
+          phrase1: 'I love coffee.',
+          phrase2: 'I dislike cats'
+        }
       }
     };
     const response = await new GenAiHubClient().chatCompletion(request);

--- a/tests/e2e-tests/src/orchestration.test.ts
+++ b/tests/e2e-tests/src/orchestration.test.ts
@@ -24,12 +24,12 @@ describe('orchestration', () => {
           {
             role: 'user',
             content:
-              'Create {{?number}} of paraphrases of {{?phrase1}} and {{?phrase2}}'
+              'Create {{?number}} paraphrases of {{?phrase1}} and {{?phrase2}}'
           }
         ],
         template_params: {
           number: '3',
-          phrase1: 'I love coffee.',
+          phrase1: 'I love coffee',
           phrase2: 'I dislike cats'
         }
       }
@@ -37,6 +37,10 @@ describe('orchestration', () => {
     const response = await new GenAiHubClient().chatCompletion(request);
 
     expect(response.module_results).toBeDefined();
+    expect(response.module_results.templating).not.toHaveLength(0);
+    expect(response.module_results.templating?.[0].content).toBe(
+      'Create 3 paraphrases of I love coffee and I dislike cats'
+    );
     expect(response.orchestration_result.choices).not.toHaveLength(0);
   });
 });


### PR DESCRIPTION
Adjusts tests as part of AI/gen-ai-hub-sdk-js-backlog#44

The way we define placeholders for parameters in the template changed, see [here](https://github.tools.sap/AI/llm-orchestration/blob/main/src/spec/api.yaml#L278), this PR adjusts tests accordingly.
I also enhanced the Orchestration E2E test, just in case, to be aware if something changes, but this can be discussed.

Before:
```TypeScript
template: [ { role: 'user', content: 'Create {number} paraphrases of {phrase}' } ]
```
After:
 ```TypeScript
template: [ { role: 'user', content: 'Create {{?number}} paraphrases of {{?phrase}}' } ]
```      