### PR TITLE
feat: Combine deployment resolution and model

### DIFF
--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -1,4 +1,4 @@
-import { removeLeadingSlashes } from '@sap-cloud-sdk/util';
+import { mergeIgnoreCase, removeLeadingSlashes } from '@sap-cloud-sdk/util';
 import {
   executeHttpRequest,
   HttpRequestConfig,
@@ -102,13 +102,13 @@ function mergeWithDefaultRequestConfig(
   return {
     ...defaultConfig,
     ...requestConfig,
-    headers: {
+    headers: mergeIgnoreCase({
       ...defaultConfig.headers,
       ...requestConfig?.headers
-    },
-    params: {
+    }),
+    params: mergeIgnoreCase({
       ...defaultConfig.params,
       ...requestConfig?.params
-    }
+    })
   };
 }

--- a/packages/gen-ai-hub/src/client/openai/openai-client.test.ts
+++ b/packages/gen-ai-hub/src/client/openai/openai-client.test.ts
@@ -59,11 +59,9 @@ describe('openai client', () => {
         chatCompletionEndpoint
       );
 
-      const response = await client.chatCompletion(
-        'gpt-35-turbo',
-        prompt,
-        '1234'
-      );
+      const response = await client.chatCompletion(prompt, {
+        deploymentId: '1234'
+      });
       expect(response).toEqual(mockResponse);
     });
 
@@ -86,7 +84,7 @@ describe('openai client', () => {
       );
 
       await expect(
-        client.chatCompletion('gpt-4', prompt, '1234')
+        client.chatCompletion(prompt, { deploymentId: '1234' })
       ).rejects.toThrow('status code 400');
     });
   });
@@ -111,11 +109,9 @@ describe('openai client', () => {
         },
         embeddingsEndpoint
       );
-      const response = await client.embeddings(
-        'text-embedding-ada-002',
-        prompt,
-        '1234'
-      );
+      const response = await client.embeddings(prompt, {
+        deploymentId: '1234'
+      });
       expect(response).toEqual(mockResponse);
     });
 
@@ -138,7 +134,7 @@ describe('openai client', () => {
       );
 
       await expect(
-        client.embeddings('text-embedding-3-large', prompt, '1234')
+        client.embeddings(prompt, { deploymentId: '1234' })
       ).rejects.toThrow('status code 400');
     });
   });

--- a/packages/gen-ai-hub/src/client/openai/openai-client.ts
+++ b/packages/gen-ai-hub/src/client/openai/openai-client.ts
@@ -105,6 +105,7 @@ function mergeRequestConfig(
 ): HttpRequestConfig {
   return {
     method: 'POST',
+    ...requestConfig,
     headers: mergeIgnoreCase(
       {
         'content-type': 'application/json'
@@ -114,7 +115,6 @@ function mergeRequestConfig(
     params: mergeIgnoreCase(
       { 'api-version': apiVersion },
       requestConfig?.params
-    ),
-    ...requestConfig
+    )
   };
 }

--- a/packages/gen-ai-hub/src/client/openai/openai-client.ts
+++ b/packages/gen-ai-hub/src/client/openai/openai-client.ts
@@ -5,13 +5,13 @@ import {
   getDeploymentId,
   type ModelDeployment
 } from '../../utils/deployment-resolver.js';
-import {
-  type OpenAiChatCompletionParameters,
-  type OpenAiEmbeddingParameters,
-  type OpenAiEmbeddingOutput,
-  type OpenAiChatCompletionOutput,
-  type OpenAiChatModel,
-  type OpenAiEmbeddingModel
+import type {
+  OpenAiChatCompletionParameters,
+  OpenAiEmbeddingParameters,
+  OpenAiEmbeddingOutput,
+  OpenAiChatCompletionOutput,
+  OpenAiChatModel,
+  OpenAiEmbeddingModel
 } from './openai-types.js';
 
 const apiVersion = '2024-02-01';

--- a/packages/gen-ai-hub/src/client/openai/openai-client.ts
+++ b/packages/gen-ai-hub/src/client/openai/openai-client.ts
@@ -1,12 +1,9 @@
 import { type HttpRequestConfig } from '@sap-cloud-sdk/http-client';
 import { type CustomRequestConfig, executeRequest } from '@sap-ai-sdk/core';
-import { mergeIgnoreCase, pickValueIgnoreCase } from '@sap-cloud-sdk/util';
+import { mergeIgnoreCase } from '@sap-cloud-sdk/util';
 import {
-  type ModelDeployment,
-  type FoundationModel,
-  type Model,
-  isDeploymentIdConfiguration,
-  resolveDeployment
+  getDeploymentId,
+  type ModelDeployment
 } from '../../utils/deployment-resolver.js';
 import {
   type OpenAiChatCompletionParameters,
@@ -26,16 +23,16 @@ export class OpenAiClient {
   /**
    * Creates a completion for the chat messages.
    * @param data - The input parameters for the chat completion.
-   * @param deploymentConfig - This configuration is used to retrieve a deployment. Depending on the configuration use either the given deployment ID or the model name to retrieve matching deployments. If model and deployment ID are given, the model is verified against the deployment.
+   * @param modelDeployment - This configuration is used to retrieve a deployment. Depending on the configuration use either the given deployment ID or the model name to retrieve matching deployments. If model and deployment ID are given, the model is verified against the deployment.
    * @param requestConfig - The request configuration.
    * @returns The completion result.
    */
   async chatCompletion(
     data: OpenAiChatCompletionParameters,
-    deploymentConfig: ModelDeployment<OpenAiChatModel>,
+    modelDeployment: ModelDeployment<OpenAiChatModel>,
     requestConfig?: CustomRequestConfig
   ): Promise<OpenAiChatCompletionOutput> {
-    const deploymentId = await getDeploymentId(deploymentConfig, requestConfig);
+    const deploymentId = await getDeploymentId(modelDeployment, requestConfig);
     const response = await executeRequest(
       {
         url: `/inference/deployments/${deploymentId}/chat/completions`,
@@ -50,16 +47,16 @@ export class OpenAiClient {
   /**
    * Creates an embedding vector representing the given text.
    * @param data - The text to embed.
-   * @param deploymentConfig - This configuration is used to retrieve a deployment. Depending on the configuration use either the given deployment ID or the model name to retrieve matching deployments. If model and deployment ID are given, the model is verified against the deployment.
+   * @param modelDeployment - This configuration is used to retrieve a deployment. Depending on the configuration use either the given deployment ID or the model name to retrieve matching deployments. If model and deployment ID are given, the model is verified against the deployment.
    * @param requestConfig - The request configuration.
    * @returns The completion result.
    */
   async embeddings(
     data: OpenAiEmbeddingParameters,
-    deploymentConfig: ModelDeployment<OpenAiEmbeddingModel>,
+    modelDeployment: ModelDeployment<OpenAiEmbeddingModel>,
     requestConfig?: CustomRequestConfig
   ): Promise<OpenAiEmbeddingOutput> {
-    const deploymentId = await getDeploymentId(deploymentConfig);
+    const deploymentId = await getDeploymentId(modelDeployment);
     const response = await executeRequest(
       { url: `/inference/deployments/${deploymentId}/embeddings`, apiVersion },
       data,
@@ -67,35 +64,6 @@ export class OpenAiClient {
     );
     return response.data;
   }
-}
-
-async function getDeploymentId(
-  deploymentConfig: ModelDeployment,
-  requestConfig?: CustomRequestConfig
-) {
-  if (isDeploymentIdConfiguration(deploymentConfig)) {
-    return deploymentConfig.deploymentId;
-  }
-
-  return (
-    await resolveDeployment({
-      scenarioId: 'foundation-models',
-      executableId: 'azure-openai',
-      model: translateToFoundationModel(deploymentConfig),
-      groupId: pickValueIgnoreCase(requestConfig?.headers, 'ai-resource-group')
-    })
-  ).id;
-}
-
-function translateToFoundationModel(modelConfig: Model): FoundationModel {
-  if (typeof modelConfig === 'string') {
-    return { name: modelConfig };
-  }
-
-  return {
-    name: modelConfig.modelName,
-    ...(modelConfig.modelVersion && { version: modelConfig.modelVersion })
-  };
 }
 
 function mergeRequestConfig(

--- a/packages/gen-ai-hub/src/client/openai/openai-client.ts
+++ b/packages/gen-ai-hub/src/client/openai/openai-client.ts
@@ -2,9 +2,9 @@ import { type HttpRequestConfig } from '@sap-cloud-sdk/http-client';
 import { type CustomRequestConfig, executeRequest } from '@sap-ai-sdk/core';
 import { mergeIgnoreCase, pickValueIgnoreCase } from '@sap-cloud-sdk/util';
 import {
-  type DeploymentConfiguration,
+  type ModelDeployment,
   type FoundationModel,
-  type ModelConfiguration,
+  type Model,
   isDeploymentIdConfiguration,
   resolveDeployment
 } from '../../utils/deployment-resolver.js';
@@ -32,7 +32,7 @@ export class OpenAiClient {
    */
   async chatCompletion(
     data: OpenAiChatCompletionParameters,
-    deploymentConfig: DeploymentConfiguration<OpenAiChatModel>,
+    deploymentConfig: ModelDeployment<OpenAiChatModel>,
     requestConfig?: CustomRequestConfig
   ): Promise<OpenAiChatCompletionOutput> {
     const deploymentId = await getDeploymentId(deploymentConfig, requestConfig);
@@ -56,7 +56,7 @@ export class OpenAiClient {
    */
   async embeddings(
     data: OpenAiEmbeddingParameters,
-    deploymentConfig: DeploymentConfiguration<OpenAiEmbeddingModel>,
+    deploymentConfig: ModelDeployment<OpenAiEmbeddingModel>,
     requestConfig?: CustomRequestConfig
   ): Promise<OpenAiEmbeddingOutput> {
     const deploymentId = await getDeploymentId(deploymentConfig);
@@ -70,7 +70,7 @@ export class OpenAiClient {
 }
 
 async function getDeploymentId(
-  deploymentConfig: DeploymentConfiguration,
+  deploymentConfig: ModelDeployment,
   requestConfig?: CustomRequestConfig
 ) {
   if (isDeploymentIdConfiguration(deploymentConfig)) {
@@ -87,9 +87,7 @@ async function getDeploymentId(
   ).id;
 }
 
-function translateToFoundationModel(
-  modelConfig: ModelConfiguration
-): FoundationModel {
+function translateToFoundationModel(modelConfig: Model): FoundationModel {
   if (typeof modelConfig === 'string') {
     return { name: modelConfig };
   }

--- a/packages/gen-ai-hub/src/client/openai/openai-client.ts
+++ b/packages/gen-ai-hub/src/client/openai/openai-client.ts
@@ -4,8 +4,8 @@ import { pickValueIgnoreCase } from '@sap-cloud-sdk/util';
 import {
   type DeploymentConfiguration,
   type FoundationModel,
+  type ModelConfiguration,
   isDeploymentIdConfiguration,
-  ModelConfiguration,
   resolveDeployment
 } from '../../utils/deployment-resolver.js';
 import {
@@ -25,20 +25,17 @@ const apiVersion = '2024-02-01';
 export class OpenAiClient {
   /**
    * Creates a completion for the chat messages.
-   * @param deploymentConfig - This configuration is used to retrieve a deployment. Depending on the configuration use either the given deployment ID or the model name to retrieve matching deployments. If model and deployment ID are given, the model is verified against the deployment.
    * @param data - The input parameters for the chat completion.
+   * @param deploymentConfig - This configuration is used to retrieve a deployment. Depending on the configuration use either the given deployment ID or the model name to retrieve matching deployments. If model and deployment ID are given, the model is verified against the deployment.
    * @param requestConfig - The request configuration.
    * @returns The completion result.
    */
   async chatCompletion(
-    deploymentConfig: DeploymentConfiguration<OpenAiChatModel>,
     data: OpenAiChatCompletionParameters,
+    deploymentConfig: DeploymentConfiguration<OpenAiChatModel>,
     requestConfig?: CustomRequestConfig
   ): Promise<OpenAiChatCompletionOutput> {
-    const deploymentId = await getDeploymentId(
-      deploymentConfig,
-      requestConfig
-    );
+    const deploymentId = await getDeploymentId(deploymentConfig, requestConfig);
     const response = await executeRequest(
       {
         url: `/inference/deployments/${deploymentId}/chat/completions`,
@@ -52,14 +49,14 @@ export class OpenAiClient {
 
   /**
    * Creates an embedding vector representing the given text.
-   * @param deploymentConfig - This configuration is used to retrieve a deployment. Depending on the configuration use either the given deployment ID or the model name to retrieve matching deployments. If model and deployment ID are given, the model is verified against the deployment.
    * @param data - The text to embed.
+   * @param deploymentConfig - This configuration is used to retrieve a deployment. Depending on the configuration use either the given deployment ID or the model name to retrieve matching deployments. If model and deployment ID are given, the model is verified against the deployment.
    * @param requestConfig - The request configuration.
    * @returns The completion result.
    */
   async embeddings(
-    deploymentConfig: DeploymentConfiguration<OpenAiEmbeddingModel>,
     data: OpenAiEmbeddingParameters,
+    deploymentConfig: DeploymentConfiguration<OpenAiEmbeddingModel>,
     requestConfig?: CustomRequestConfig
   ): Promise<OpenAiEmbeddingOutput> {
     const deploymentId = await getDeploymentId(deploymentConfig);

--- a/packages/gen-ai-hub/src/client/openai/openai-client.ts
+++ b/packages/gen-ai-hub/src/client/openai/openai-client.ts
@@ -1,6 +1,4 @@
-import { type HttpRequestConfig } from '@sap-cloud-sdk/http-client';
 import { type CustomRequestConfig, executeRequest } from '@sap-ai-sdk/core';
-import { mergeIgnoreCase } from '@sap-cloud-sdk/util';
 import {
   getDeploymentId,
   type ModelDeployment
@@ -68,27 +66,8 @@ export class OpenAiClient {
     const response = await executeRequest(
       { url: `/inference/deployments/${deploymentId}/embeddings`, apiVersion },
       data,
-      mergeRequestConfig(requestConfig)
+      requestConfig
     );
     return response.data;
   }
-}
-
-function mergeRequestConfig(
-  requestConfig?: CustomRequestConfig
-): HttpRequestConfig {
-  return {
-    method: 'POST',
-    ...requestConfig,
-    headers: mergeIgnoreCase(
-      {
-        'content-type': 'application/json'
-      },
-      requestConfig?.headers
-    ),
-    params: mergeIgnoreCase(
-      { 'api-version': apiVersion },
-      requestConfig?.params
-    )
-  };
 }

--- a/packages/gen-ai-hub/src/client/openai/openai-client.ts
+++ b/packages/gen-ai-hub/src/client/openai/openai-client.ts
@@ -1,6 +1,6 @@
 import { type HttpRequestConfig } from '@sap-cloud-sdk/http-client';
 import { type CustomRequestConfig, executeRequest } from '@sap-ai-sdk/core';
-import { pickValueIgnoreCase } from '@sap-cloud-sdk/util';
+import { mergeIgnoreCase, pickValueIgnoreCase } from '@sap-cloud-sdk/util';
 import {
   type DeploymentConfiguration,
   type FoundationModel,
@@ -100,16 +100,21 @@ function translateToFoundationModel(
   };
 }
 
-// TODO: merge headers and query params too?!
 function mergeRequestConfig(
   requestConfig?: CustomRequestConfig
 ): HttpRequestConfig {
   return {
     method: 'POST',
-    headers: {
-      'content-type': 'application/json'
-    },
-    params: { 'api-version': apiVersion },
+    headers: mergeIgnoreCase(
+      {
+        'content-type': 'application/json'
+      },
+      requestConfig?.headers
+    ),
+    params: mergeIgnoreCase(
+      { 'api-version': apiVersion },
+      requestConfig?.params
+    ),
     ...requestConfig
   };
 }

--- a/packages/gen-ai-hub/src/client/openai/openai-client.ts
+++ b/packages/gen-ai-hub/src/client/openai/openai-client.ts
@@ -41,7 +41,7 @@ export class OpenAiClient {
         apiVersion
       },
       data,
-      mergeRequestConfig(requestConfig)
+      requestConfig
     );
     return response.data;
   }

--- a/packages/gen-ai-hub/src/client/openai/openai-client.ts
+++ b/packages/gen-ai-hub/src/client/openai/openai-client.ts
@@ -32,7 +32,11 @@ export class OpenAiClient {
     modelDeployment: ModelDeployment<OpenAiChatModel>,
     requestConfig?: CustomRequestConfig
   ): Promise<OpenAiChatCompletionOutput> {
-    const deploymentId = await getDeploymentId(modelDeployment, requestConfig);
+    const deploymentId = await getDeploymentId(
+      modelDeployment,
+      'azure-openai',
+      requestConfig
+    );
     const response = await executeRequest(
       {
         url: `/inference/deployments/${deploymentId}/chat/completions`,
@@ -56,7 +60,11 @@ export class OpenAiClient {
     modelDeployment: ModelDeployment<OpenAiEmbeddingModel>,
     requestConfig?: CustomRequestConfig
   ): Promise<OpenAiEmbeddingOutput> {
-    const deploymentId = await getDeploymentId(modelDeployment);
+    const deploymentId = await getDeploymentId(
+      modelDeployment,
+      'azure-openai',
+      requestConfig
+    );
     const response = await executeRequest(
       { url: `/inference/deployments/${deploymentId}/embeddings`, apiVersion },
       data,

--- a/packages/gen-ai-hub/src/orchestration/orchestration-client.ts
+++ b/packages/gen-ai-hub/src/orchestration/orchestration-client.ts
@@ -1,8 +1,5 @@
 import { executeRequest, CustomRequestConfig } from '@sap-ai-sdk/core';
-import {
-  DeploymentResolver,
-  resolveDeployment
-} from '../utils/deployment-resolver.js';
+import { resolveDeployment } from '../utils/deployment-resolver.js';
 import {
   CompletionPostRequest,
   CompletionPostResponse
@@ -16,25 +13,31 @@ export class OrchestrationClient {
   /**
    * Creates a completion for the chat messages.
    * @param data - The input parameters for the chat completion.
-   * @param deploymentResolver - A deployment ID or a function to retrieve it.
+   * @param deploymentId - A deployment ID or undefined to retrieve it based on the given model.
    * @param requestConfig - Request configuration.
    * @returns The completion result.
    */
   async chatCompletion(
     data: OrchestrationCompletionParameters,
-    deploymentResolver: DeploymentResolver = () =>
-      resolveDeployment({ scenarioId: 'orchestration' }),
+    deploymentId?: string,
     requestConfig?: CustomRequestConfig
   ): Promise<CompletionPostResponse> {
     const body = constructCompletionPostRequest(data);
-    const deployment =
-      typeof deploymentResolver === 'function'
-        ? (await deploymentResolver()).id
-        : deploymentResolver;
+    deploymentId =
+      deploymentId ??
+      (
+        await resolveDeployment({
+          scenarioId: 'orchestration',
+          model: {
+            name: data.llmConfig.model_name,
+            version: data.llmConfig.model_version
+          }
+        })
+      ).id;
 
     const response = await executeRequest(
       {
-        url: `/inference/deployments/${deployment}/completion`
+        url: `/inference/deployments/${deploymentId}/completion`
       },
       body,
       requestConfig

--- a/packages/gen-ai-hub/src/orchestration/orchestration-client.ts
+++ b/packages/gen-ai-hub/src/orchestration/orchestration-client.ts
@@ -1,4 +1,5 @@
 import { executeRequest, CustomRequestConfig } from '@sap-ai-sdk/core';
+import { pickValueIgnoreCase } from '@sap-cloud-sdk/util';
 import { resolveDeployment } from '../utils/deployment-resolver.js';
 import {
   CompletionPostRequest,
@@ -31,7 +32,11 @@ export class OrchestrationClient {
           model: {
             name: data.llmConfig.model_name,
             version: data.llmConfig.model_version
-          }
+          },
+          resourceGroup: pickValueIgnoreCase(
+            requestConfig?.headers,
+            'ai-resource-group'
+          )
         })
       ).id;
 

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.test.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.test.ts
@@ -111,7 +111,7 @@ describe('deployment resolver', () => {
     const { id } = await resolveDeployment({
       scenarioId: 'foundation-models',
       model: { name: 'gpt-4o' },
-      groupId: 'otherId'
+      resourceGroup: 'otherId'
     });
 
     expect(id).toBe('5');

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.test.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.test.ts
@@ -19,13 +19,13 @@ describe('deployment resolver', () => {
       mockResponse();
     });
 
-    // it('should return the first deployment, if multiple are given', async () => {
-    //   const { id, configurationId } = await resolveDeployment({
-    //     scenarioId: 'foundation-models',
-    //   });
-    //   expect(id).toBe('1');
-    //   expect(configurationId).toBe('c1');
-    // });
+    it('should return the first deployment, if multiple are given', async () => {
+      const { id, configurationId } = await resolveDeployment({
+        scenarioId: 'foundation-models'
+      });
+      expect(id).toBe('1');
+      expect(configurationId).toBe('c1');
+    });
 
     it('should return the first deployment with the correct model name', async () => {
       const { id } = await resolveDeployment({

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.test.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.test.ts
@@ -20,11 +20,10 @@ describe('deployment resolver', () => {
     });
 
     it('should return the first deployment, if multiple are given', async () => {
-      const { id, configurationId } = await resolveDeployment({
+      const { id } = await resolveDeployment({
         scenarioId: 'foundation-models'
       });
       expect(id).toBe('1');
-      expect(configurationId).toBe('c1');
     });
 
     it('should return the first deployment with the correct model name', async () => {

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.test.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.test.ts
@@ -82,7 +82,7 @@ describe('deployment resolver', () => {
     ).rejects.toThrow('No deployment matched the given criteria');
   });
 
-  it('should consider group ID', async () => {
+  it('should consider custom resource group', async () => {
     nock(aiCoreDestination.url, {
       reqheaders: {
         'ai-resource-group': 'otherId'

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.ts
@@ -1,19 +1,65 @@
-import {
-  DeploymentApi,
-  AiDeployment,
-  AiDeploymentStatus
-} from '@sap-ai-sdk/ai-core';
+import { DeploymentApi, AiDeployment } from '@sap-ai-sdk/ai-core';
+
+/**
+ * The deployment configuration when using a model. It can be either the name of the model or an object containing the name and version of the model.
+ * @typeParam ModelNameT - String literal type representing the name of the model.
+ */
+export type ModelConfiguration<ModelNameT = string> =
+  | ModelNameT
+  | {
+      /**
+       * The name of the model.
+       */
+      modelName: ModelNameT;
+      /**
+       * The version of the model.
+       */
+      modelVersion?: string;
+    };
+
+/**
+ * The deployment configuration when using a deployment ID.
+ */
+export interface DeploymentIdConfiguration {
+  /**
+   * The deployment ID.
+   */
+  deploymentId: string;
+}
+
+/**
+ * The deployment configuration can be either a model configuration or a deployment ID configuration.
+ * @typeParam ModelNameT - String literal type representing the name of the model.
+ */
+export type DeploymentConfiguration<ModelNameT = string> =
+  | ModelConfiguration<ModelNameT>
+  | DeploymentIdConfiguration;
+
+/**
+ * Type guard to check if the given deployment configuration is a deployment ID configuration.
+ * @param deploymentConfig - Configuration to check.
+ * @returns `true` if the configuration is a deployment ID configuration, `false` otherwise.
+ */
+export function isDeploymentIdConfiguration(
+  deploymentConfig: DeploymentConfiguration
+): deploymentConfig is DeploymentIdConfiguration {
+  return (
+    typeof deploymentConfig === 'object' && 'deploymentId' in deploymentConfig
+  );
+}
 
 /**
  * A deployment resolver can be either a deployment ID or a function that returns a full deployment object.
  */
 export type DeploymentResolver = DeploymentId | (() => Promise<AiDeployment>);
+
 /**
  * A deployment ID is a string that uniquely identifies a deployment.
  */
 export type DeploymentId = string;
+
 /**
- * A foundation model is identifier by its name and potentially a version.
+ * A foundation model is identified by its name and potentially a version.
  */
 export interface FoundationModel {
   /**
@@ -27,56 +73,82 @@ export interface FoundationModel {
 }
 
 /**
+ * The options for the deployment resolution.
+ */
+interface DeploymentResolutionOptions {
+  /**
+   * The scenario ID of the deployment.
+   */
+  scenarioId: string;
+  /**
+   * The executable ID of the deployment.
+   */
+  executableId?: string;
+  /**
+   * The name and potentially version of the model to look for.
+   */
+  model?: FoundationModel;
+  /**
+   * The group ID of the deployment.
+   */
+  groupId?: string;
+}
+
+/**
  * Query the AI Core service for a deployment that matches the given criteria. If more than one deployment matches the criteria, the first one is returned.
  * @param opts - The options for the deployment resolution.
- * @param opts.scenarioId - The scenario ID of the deployment.
- * @param opts.executableId - The executable of the deployment.
- * @param opts.model - The name and potentially version of the model to look for.
- * @returns An AiDeployment, if a deployment was found, fails otherwise.
+ * @returns A promise of a deployment, if a deployment was found, fails otherwise.
  */
-export async function resolveDeployment(opts: {
-  scenarioId: string;
-  executableId?: string;
-  model?: FoundationModel;
-}): Promise<AiDeployment> {
-  const query = {
-    scenarioId: opts.scenarioId,
-    status: 'RUNNING' as AiDeploymentStatus,
-    ...(opts.executableId && { executableIds: [opts.executableId] })
-  };
+export async function resolveDeployment(
+  opts: DeploymentResolutionOptions
+): Promise<AiDeployment> {
+  const { model } = opts;
 
-  // TODO: add a cache: https://github.tools.sap/AI/gen-ai-hub-sdk-js-backlog/issues/78
-  let deploymentList: AiDeployment[];
-  const { deploymentQuery } = DeploymentApi;
-  const resourceGroup = { 'AI-Resource-Group': 'default' };
-  try {
-    deploymentList = (await deploymentQuery(query, resourceGroup).execute())
-      .resources;
-  } catch (error) {
-    throw new Error('Failed to fetch the list of deployments: ' + error);
-  }
+  let deployments = await getAllDeployments(opts);
 
-  if (opts.model) {
-    const modelName = opts.model.name;
-    deploymentList = deploymentList.filter(
-      deployment => extractModel(deployment)?.name === modelName
+  if (model) {
+    deployments = deployments.filter(
+      deployment => extractModel(deployment)?.name === model.name
     );
-    if (opts.model.version) {
-      const modelVersion = opts.model.version;
-      // feature idea: smart handling of 'latest' version: treat 'latest' and the highest version number as the same
-      deploymentList = deploymentList.filter(
-        deployment => extractModel(deployment)?.version === modelVersion
+
+    if (model.version) {
+      deployments = deployments.filter(
+        deployment => extractModel(deployment)?.version === model.version
       );
     }
   }
 
-  if (!deploymentList.length) {
+  if (!deployments.length) {
     throw new Error(
       'No deployment matched the given criteria: ' + JSON.stringify(opts)
     );
   }
-  return deploymentList[0];
+  return deployments[0];
 }
 
-const extractModel = (deployment: AiDeployment) =>
-  deployment.details?.resources?.backend_details?.model;
+async function getAllDeployments(
+  opts: DeploymentResolutionOptions
+): Promise<AiDeployment[]> {
+  const { scenarioId, executableId, groupId = 'default' } = opts;
+  // TODO: add a cache: https://github.tools.sap/AI/gen-ai-hub-sdk-js-backlog/issues/78
+  try {
+    return (
+      await DeploymentApi.deploymentQuery(
+        {
+          scenarioId,
+          status: 'RUNNING',
+          ...(executableId && { executableIds: [executableId] })
+        },
+        { 'AI-Resource-Group': groupId }
+      ).execute()
+    ).resources;
+  } catch (error) {
+    throw new Error('Failed to fetch the list of deployments: ' + error);
+  }
+}
+
+function extractModel(
+  deployment: AiDeployment
+): Partial<FoundationModel> | undefined {
+  return deployment.details?.resources?.backend_details?.model;
+}

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.ts
@@ -83,7 +83,7 @@ interface DeploymentResolutionOptions {
   /**
    * The name and potentially version of the model to look for.
    */
-  model: FoundationModel;
+  model?: FoundationModel;
   /**
    * The executable ID of the deployment.
    */

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.ts
@@ -39,14 +39,14 @@ export type ModelDeployment<ModelNameT = string> =
 
 /**
  * Type guard to check if the given deployment configuration is a deployment ID configuration.
- * @param deploymentConfig - Configuration to check.
+ * @param modelDeployment - Configuration to check.
  * @returns `true` if the configuration is a deployment ID configuration, `false` otherwise.
  */
 export function isDeploymentIdConfiguration(
-  deploymentConfig: ModelDeployment
-): deploymentConfig is DeploymentIdConfiguration {
+  modelDeployment: ModelDeployment
+): modelDeployment is DeploymentIdConfiguration {
   return (
-    typeof deploymentConfig === 'object' && 'deploymentId' in deploymentConfig
+    typeof modelDeployment === 'object' && 'deploymentId' in modelDeployment
   );
 }
 

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.ts
@@ -20,7 +20,7 @@ export type ModelConfiguration<ModelNameT = string> =
 /**
  * The deployment configuration when using a deployment ID.
  */
-export interface DeploymentIdConfiguration {
+export interface DeploymentId {
   /**
    * The deployment ID.
    */
@@ -31,9 +31,9 @@ export interface DeploymentIdConfiguration {
  * The deployment configuration can be either a model configuration or a deployment ID configuration.
  * @typeParam ModelNameT - String literal type representing the name of the model.
  */
-export type DeploymentConfiguration<ModelNameT = string> =
+export type ModelDeployment<ModelNameT = string> =
   | ModelConfiguration<ModelNameT>
-  | DeploymentIdConfiguration;
+  | DeploymentId;
 
 /**
  * Type guard to check if the given deployment configuration is a deployment ID configuration.
@@ -41,22 +41,12 @@ export type DeploymentConfiguration<ModelNameT = string> =
  * @returns `true` if the configuration is a deployment ID configuration, `false` otherwise.
  */
 export function isDeploymentIdConfiguration(
-  deploymentConfig: DeploymentConfiguration
-): deploymentConfig is DeploymentIdConfiguration {
+  deploymentConfig: ModelDeployment
+): deploymentConfig is DeploymentId {
   return (
     typeof deploymentConfig === 'object' && 'deploymentId' in deploymentConfig
   );
 }
-
-/**
- * A deployment resolver can be either a deployment ID or a function that returns a full deployment object.
- */
-export type DeploymentResolver = DeploymentId | (() => Promise<AiDeployment>);
-
-/**
- * A deployment ID is a string that uniquely identifies a deployment.
- */
-export type DeploymentId = string;
 
 /**
  * A foundation model is identified by its name and potentially a version.

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.ts
@@ -81,13 +81,13 @@ interface DeploymentResolutionOptions {
    */
   scenarioId: string;
   /**
+   * The name and potentially version of the model to look for.
+   */
+  model: FoundationModel;
+  /**
    * The executable ID of the deployment.
    */
   executableId?: string;
-  /**
-   * The name and potentially version of the model to look for.
-   */
-  model?: FoundationModel;
   /**
    * The group ID of the deployment.
    */

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.ts
@@ -148,11 +148,13 @@ function extractModel(
 /**
  * Get the deployment ID for a given model deployment configuration and executable ID.
  * @param modelDeployment - The model deployment configuration.
+ * @param executableId - The executable ID.
  * @param requestConfig - The request configuration.
  * @returns The ID of the deployment, if found.
  */
 export async function getDeploymentId(
   modelDeployment: ModelDeployment,
+  executableId: string,
   requestConfig?: CustomRequestConfig
 ): Promise<string> {
   if (isDeploymentIdConfiguration(modelDeployment)) {
@@ -162,7 +164,7 @@ export async function getDeploymentId(
   return (
     await resolveDeployment({
       scenarioId: 'foundation-models',
-      executableId: 'azure-openai',
+      executableId,
       model: translateToFoundationModel(modelDeployment),
       groupId: pickValueIgnoreCase(requestConfig?.headers, 'ai-resource-group')
     })

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.ts
@@ -146,7 +146,7 @@ function extractModel(
 }
 
 /**
- * Get the deployment ID for a given model deployment configuration and executable ID.
+ * Get the deployment ID for a given model deployment configuration and executable ID using the 'foundation-models' scenario.
  * @param modelDeployment - The model deployment configuration.
  * @param executableId - The executable ID.
  * @param requestConfig - The request configuration.

--- a/packages/gen-ai-hub/src/utils/deployment-resolver.ts
+++ b/packages/gen-ai-hub/src/utils/deployment-resolver.ts
@@ -81,9 +81,9 @@ interface DeploymentResolutionOptions {
    */
   executableId?: string;
   /**
-   * The group ID of the deployment.
+   * The resource group of the deployment.
    */
-  groupId?: string;
+  resourceGroup?: string;
 }
 
 /**
@@ -121,7 +121,7 @@ export async function resolveDeployment(
 async function getAllDeployments(
   opts: DeploymentResolutionOptions
 ): Promise<AiDeployment[]> {
-  const { scenarioId, executableId, groupId = 'default' } = opts;
+  const { scenarioId, executableId, resourceGroup = 'default' } = opts;
   // TODO: add a cache: https://github.tools.sap/AI/gen-ai-hub-sdk-js-backlog/issues/78
   try {
     return (
@@ -131,7 +131,7 @@ async function getAllDeployments(
           status: 'RUNNING',
           ...(executableId && { executableIds: [executableId] })
         },
-        { 'AI-Resource-Group': groupId }
+        { 'AI-Resource-Group': resourceGroup }
       ).execute()
     ).resources;
   } catch (error) {
@@ -166,7 +166,10 @@ export async function getDeploymentId(
       scenarioId: 'foundation-models',
       executableId,
       model: translateToFoundationModel(modelDeployment),
-      groupId: pickValueIgnoreCase(requestConfig?.headers, 'ai-resource-group')
+      resourceGroup: pickValueIgnoreCase(
+        requestConfig?.headers,
+        'ai-resource-group'
+      )
     })
   ).id;
 }

--- a/sample-code/src/aiservice.ts
+++ b/sample-code/src/aiservice.ts
@@ -10,9 +10,12 @@ const openAiClient = new OpenAiClient();
  * @returns The answer from GPT.
  */
 export async function chatCompletion(): Promise<string> {
-  const response = await openAiClient.chatCompletion('gpt-35-turbo', {
-    messages: [{ role: 'user', content: 'What is the capital of France?' }]
-  });
+  const response = await openAiClient.chatCompletion(
+    {
+      messages: [{ role: 'user', content: 'What is the capital of France?' }]
+    },
+    'gpt-35-turbo'
+  );
   const assistantMessage = response.choices[0]
     .message as OpenAiChatAssistantMessage;
   return assistantMessage.content!;
@@ -23,8 +26,12 @@ export async function chatCompletion(): Promise<string> {
  * @returns An embedding vector.
  */
 export async function computeEmbedding(): Promise<number[]> {
-  const response = await openAiClient.embeddings('text-embedding-ada-002', {
-    input: 'Hello, world!'
-  });
+  const response = await openAiClient.embeddings(
+    {
+      input: 'Hello, world!'
+    },
+    'text-embedding-ada-002'
+  );
+
   return response.data[0].embedding;
 }

--- a/tests/type-tests/test/openai.test-d.ts
+++ b/tests/type-tests/test/openai.test-d.ts
@@ -12,18 +12,24 @@ expectType<OpenAiClient>(client);
  * Chat Completion.
  */
 expectType<Promise<OpenAiChatCompletionOutput>>(
-  client.chatCompletion('gpt-4', {
-    messages: [{ role: 'user', content: 'test prompt' }]
-  })
+  client.chatCompletion(
+    {
+      messages: [{ role: 'user', content: 'test prompt' }]
+    },
+    'gpt-4'
+  )
 );
 
 /**
  * Embeddings.
  */
 expectType<Promise<OpenAiEmbeddingOutput>>(
-  client.embeddings('text-embedding-ada-002', {
-    input: 'test input'
-  })
+  client.embeddings(
+    {
+      input: 'test input'
+    },
+    'text-embedding-ada-002'
+  )
 );
 
-expectError<any>(client.embeddings('gpt-35-turbo', { input: 'test input' }));
+expectError<any>(client.embeddings({ input: 'test input' }, 'gpt-35-turbo'));


### PR DESCRIPTION
## Context

AI/gen-ai-hub-sdk-js-backlog#92.

This combines the deployment ID and model into one parameter. I also refactored some of the code to be more concise and fixed some issues that I found along the way.

Unfortunately the API does not get better for orchestration. Regardless, I would like to merge this one before adjusting it in here and getting inspired from python.

## Definition of Done

- [x] Code is tested (Unit, E2E)
- [x] Error handling created / updated & covered by the tests above
- [x] Documentation updated
- [x] (Optional) ~Aligned changes with the Java SDK~
- [x] (Optional) ~Release notes updated~