### PR TITLE
fix: Internal files should also be ESM

### DIFF
--- a/packages/core/internal.d.ts
+++ b/packages/core/internal.d.ts
@@ -1,3 +1,2 @@
-// eslint-disable-next-line import/no-internal-modules
 export * from './dist/internal.js';
-// # sourceMappingURL=internal.d.ts.map
+//# sourceMappingURL=internal.d.ts.map

--- a/packages/core/internal.js
+++ b/packages/core/internal.js
@@ -1,15 +1,2 @@
-'use strict';
-function __export(m) {
-  for (const p in m) {
-    if (!exports.hasOwnProperty(p)) {
-      exports[p] = m[p];
-    }
-  }
-}
-Object.defineProperty(exports, '__esModule', { value: true });
-/**
- * @packageDocumentation
- * @experimental The internal module is related to sdk-metadata types which are used only internally.
- */
-__export(require('./dist/internal'));
-// # sourceMappingURL=internal.js.map
+export * from './dist/internal.js';
+//# sourceMappingURL=internal.js.map

--- a/packages/gen-ai-hub/internal.js
+++ b/packages/gen-ai-hub/internal.js
@@ -1,15 +1,2 @@
-'use strict';
-function __export(m) {
-  for (const p in m) {
-    if (!exports.hasOwnProperty(p)) {
-      exports[p] = m[p];
-    }
-  }
-}
-Object.defineProperty(exports, '__esModule', { value: true });
-/**
- * @packageDocumentation
- * @experimental The internal module is related to sdk-metadata types which are used only internally.
- */
-__export(require('./dist/internal'));
-// # sourceMappingURL=internal.js.map
+export * from './dist/internal.js';
+//# sourceMappingURL=internal.js.map


### PR DESCRIPTION
## Context

I noticed the files were exporting CJS instead of ESM. Somehow this causes issues in ai-core where I wanted to add this, but not in the other packages ¯\\\_(ツ)\_/¯ 
