### PR TITLE
chore: generate CJS build info files in dist-cjs

### DIFF
--- a/packages/ai-core/tsconfig.cjs.json
+++ b/packages/ai-core/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "outDir": "./dist-cjs"
+    "outDir": "./dist-cjs",
+    "tsBuildInfoFile": "./dist-cjs/.tsbuildinfo"
   }
 }

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "outDir": "./dist-cjs"
+    "outDir": "./dist-cjs",
+    "tsBuildInfoFile": "./dist-cjs/.tsbuildinfo"
   }
 }

--- a/packages/gen-ai-hub/tsconfig.cjs.json
+++ b/packages/gen-ai-hub/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "outDir": "./dist-cjs"
+    "outDir": "./dist-cjs",
+    "tsBuildInfoFile": "./dist-cjs/.tsbuildinfo"
   }
 }


### PR DESCRIPTION
## Context

Accidentally noticed that those files are written into the dist dir, which might not be expected (doesn't cause issues afaik though).