### PR TITLE
fix: Update public api script

### DIFF
--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -138,7 +138,7 @@ export async function checkApiOfPackage(pathToPackage: string): Promise<void> {
         usePrettier: false
       }
     }, { exclude: includeExclude?.exclude!, include: ['**/*.ts'] });
-    await checkBarrelRecursive(pathToSource);
+    // await checkBarrelRecursive(pathToSource);
 
     const indexFilePath = join(pathToSource, 'index.ts');
     checkIndexFileExists(indexFilePath);

--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -177,7 +177,9 @@ export function checkIndexFileExists(indexFilePath: string): void {
 export async function typeDescriptorPaths(cwd: string): Promise<string[]> {
   const files = await glob('**/*.d.ts', { cwd });
   return files
-    .filter(file => !file.endsWith('index.d.ts'))
+    .filter(file => 
+      !file.endsWith('index.d.ts') &&
+      !file.startsWith('client\\AI_CORE_API\\'))
     .map(file => join(cwd, file));
 }
 
@@ -292,7 +294,7 @@ export async function checkBarrelRecursive(cwd: string): Promise<void> {
   (await readdir(cwd, { withFileTypes: true }))
     .filter(dirent => dirent.isDirectory())
     .forEach(async subDir => {
-      if (['__snapshot__', 'spec'].includes(subDir.name)) {
+      if (!['__snapshot__', 'spec'].includes(subDir.name)) {
         await checkBarrelRecursive(join(cwd, subDir.name));
       }
     });
@@ -314,6 +316,7 @@ export async function exportAllInBarrel(
           '**/*.test.ts',
           '__snapshots__',
           'spec',
+          'tests',
           'internal.ts',
           'index.ts',
           'cli.ts',

--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -177,9 +177,7 @@ export function checkIndexFileExists(indexFilePath: string): void {
 export async function typeDescriptorPaths(cwd: string): Promise<string[]> {
   const files = await glob('**/*.d.ts', { cwd });
   return files
-    .filter(file => 
-      !file.endsWith('index.d.ts') &&
-      !file.startsWith('client\\AI_CORE_API\\'))
+    .filter(file => !file.endsWith('index.d.ts'))
     .map(file => join(cwd, file));
 }
 
@@ -274,7 +272,7 @@ export async function parseIndexFile(filePath: string): Promise<string[]> {
   const starFiles = captureGroupsFromGlobalRegex(
     /export \* from '([\w\/.-]+)'/g,
     fileContent
-  ).filter(file => file !== './client/AI_CORE_API/index.js');
+  );
   const starFileExports = await Promise.all(
     starFiles.map(async relativeFilePath => {
       const fullPath = resolve(cwd, relativeFilePath);

--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -274,7 +274,7 @@ export async function parseIndexFile(filePath: string): Promise<string[]> {
   const starFiles = captureGroupsFromGlobalRegex(
     /export \* from '([\w\/.-]+)'/g,
     fileContent
-  );
+  ).filter(file => file !== './client/AI_CORE_API/index.js');
   const starFileExports = await Promise.all(
     starFiles.map(async relativeFilePath => {
       const fullPath = resolve(cwd, relativeFilePath);
@@ -294,7 +294,7 @@ export async function checkBarrelRecursive(cwd: string): Promise<void> {
   (await readdir(cwd, { withFileTypes: true }))
     .filter(dirent => dirent.isDirectory())
     .forEach(async subDir => {
-      if (!['__snapshot__', 'spec'].includes(subDir.name)) {
+      if (!['__snapshot__', 'spec', 'tests'].includes(subDir.name)) {
         await checkBarrelRecursive(join(cwd, subDir.name));
       }
     });


### PR DESCRIPTION
## Context


Updating the script to ignore AI_CORE_CLIENTS during the checking process because by default, everything in there should be public. 
This is just a temporary workaround to merge https://github.com/SAP/ai-sdk-js/pull/107. We would ideally split the script to handle external imports and internal imports separately in the future.

## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated