### PR TITLE
fix: Remove method property

### DIFF
--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -32,7 +32,6 @@ export type CustomRequestConfig = Pick<
   HttpRequestConfig,
   | 'headers'
   | 'params'
-  | 'method'
   | 'middleware'
   | 'maxContentLength'
   | 'proxy'

--- a/tests/type-tests/test/http-client.test-d.ts
+++ b/tests/type-tests/test/http-client.test-d.ts
@@ -11,7 +11,7 @@ expectType<Promise<HttpResponse>>(
 
 expectError<any>(executeRequest({}, { prompt: 'test prompt' }));
 
-expectError<Promise<HttpResponse>>(
+expectType<Promise<HttpResponse>>(
   executeRequest(
     { url: 'https://example.com', apiVersion: 'v1' },
     { deploymentConfiguration: { deploymentId: 'test-id' } },


### PR DESCRIPTION
## Context

AI/gen-ai-hub-sdk-js-backlog#106.

Remove `method` property from `CustomRequestConfig` as user should not define it. Currently, it is even mandatory to define this property.

## Definition of Done

- [X] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated