### PR TITLE
chore: Change nightly test schedule

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -3,7 +3,7 @@ name: smoke test
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 22 * * *
+    - cron: 0 2 * * *
 
 jobs:
   smoke-tests:


### PR DESCRIPTION
## Context

AI/gen-ai-hub-sdk-js-backlog#107.

With this PR we fix the smoke tests, or rather run them after we released a new canary version.

Canary versions are released everyday at 1 AM, now our smoke tests run at 2 AM.

## Definition of Done

- [x] ~Code is tested (Unit, E2E)~
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~(Optional) Aligned changes with the Java SDK~
- [x] ~(Optional) Release notes updated~