### PR TITLE
revert: Use canary versions for smoke tests dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,14 +223,14 @@ importers:
   tests/smoke-tests:
     dependencies:
       '@sap-ai-sdk/ai-api':
-        specifier: workspace:^
-        version: link:../../packages/ai-api
+        specifier: canary
+        version: 0.1.1-20240910013040.0
       '@sap-ai-sdk/foundation-models':
-        specifier: workspace:^
-        version: link:../../packages/foundation-models
+        specifier: canary
+        version: 0.1.1-20240910013040.0
       '@sap-ai-sdk/orchestration':
-        specifier: workspace:^
-        version: link:../../packages/orchestration
+        specifier: canary
+        version: 0.1.1-20240910013040.0
       express:
         specifier: ^4.19.2
         version: 4.19.2
@@ -747,6 +747,18 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@sap-ai-sdk/ai-api@0.1.1-20240910013040.0':
+    resolution: {integrity: sha512-NF4jJTHtkvnn9q5b8JA0wAsSFcFbSLbcmPEwoNKQ2Xfs8LTvdBGp3jPUy+duqBEHMhdVbNk3WVBmF9zgrI0D5g==}
+
+  '@sap-ai-sdk/core@0.1.1-20240910013040.0':
+    resolution: {integrity: sha512-6Yp3VmMn9vIbDVWQDfhKQmrw9vtn2r0vhm3Hc9svSUH3PeHdKbL0ptJpBj1Ja2Ae5k2RKVFZGGSn6tL9cAz49g==}
+
+  '@sap-ai-sdk/foundation-models@0.1.1-20240910013040.0':
+    resolution: {integrity: sha512-P9NvZcie81B0E6vHmgNhKI4fraOs7/LRXGJ1fSXRthgY9uqyjarsJw41nnsYn8shZZvRRlsB406IoTZXN3jn3g==}
+
+  '@sap-ai-sdk/orchestration@0.1.1-20240910013040.0':
+    resolution: {integrity: sha512-BO2XOBYs9jFU4Cfwluc3N58RspFkMioA5MFu+X42NexbAWhxUtggOAwH1F7/IhFPdu/Hfo2t39R4MywvmuF0ww==}
 
   '@sap-cloud-sdk/connectivity@3.20.0':
     resolution: {integrity: sha512-H9jWH6+owUu0vDiz1WWgB+o/1LzFnmmvELUHakdQSU1n930giPOBT9wwCmdbQgsQ+MJ4G6GURyqo9eKberBdXg==}
@@ -4276,6 +4288,51 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.1': {}
+
+  '@sap-ai-sdk/ai-api@0.1.1-20240910013040.0':
+    dependencies:
+      '@sap-ai-sdk/core': 0.1.1-20240910013040.0
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - supports-color
+
+  '@sap-ai-sdk/core@0.1.1-20240910013040.0':
+    dependencies:
+      '@sap-cloud-sdk/connectivity': 3.20.0
+      '@sap-cloud-sdk/http-client': 3.20.0
+      '@sap-cloud-sdk/openapi': 3.20.0
+      '@sap-cloud-sdk/util': 3.20.0
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - supports-color
+
+  '@sap-ai-sdk/foundation-models@0.1.1-20240910013040.0':
+    dependencies:
+      '@sap-ai-sdk/ai-api': 0.1.1-20240910013040.0
+      '@sap-ai-sdk/core': 0.1.1-20240910013040.0
+      '@sap-cloud-sdk/connectivity': 3.20.0
+      '@sap-cloud-sdk/http-client': 3.20.0
+      '@sap-cloud-sdk/openapi': 3.20.0
+      '@sap-cloud-sdk/util': 3.20.0
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - supports-color
+
+  '@sap-ai-sdk/orchestration@0.1.1-20240910013040.0':
+    dependencies:
+      '@sap-ai-sdk/ai-api': 0.1.1-20240910013040.0
+      '@sap-ai-sdk/core': 0.1.1-20240910013040.0
+      '@sap-cloud-sdk/connectivity': 3.20.0
+      '@sap-cloud-sdk/http-client': 3.20.0
+      '@sap-cloud-sdk/openapi': 3.20.0
+      '@sap-cloud-sdk/util': 3.20.0
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - supports-color
 
   '@sap-cloud-sdk/connectivity@3.20.0':
     dependencies:

--- a/tests/smoke-tests/package.json
+++ b/tests/smoke-tests/package.json
@@ -18,9 +18,9 @@
     "node": "^20"
   },
   "dependencies": {
-    "@sap-ai-sdk/ai-api": "workspace:^",
-    "@sap-ai-sdk/foundation-models": "workspace:^",
-    "@sap-ai-sdk/orchestration": "workspace:^",
+    "@sap-ai-sdk/ai-api": "canary",
+    "@sap-ai-sdk/foundation-models": "canary",
+    "@sap-ai-sdk/orchestration": "canary",
     "express": "^4.19.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Context

AI/gen-ai-hub-sdk-js-backlog#80.

Use canary versions for ai sdk packages in smoke tests.

## Definition of Done

- [X] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated