### PR TITLE
fix: Merge request config headers and params

### DIFF
--- a/packages/ai-api/src/tests/deployment-api.test.ts
+++ b/packages/ai-api/src/tests/deployment-api.test.ts
@@ -89,7 +89,7 @@ describe('deployment', () => {
         'AI-Resource-Group': 'default',
         'some-test-header': 'test-header-value',
         'content-type': 'application/json',
-        'ai-client-type': 'AI SD JavaScript'
+        'ai-client-type': 'AI SDK JavaScript'
       }
     })
       .post('/v2/lm/deployments')

--- a/packages/ai-api/src/tests/deployment-api.test.ts
+++ b/packages/ai-api/src/tests/deployment-api.test.ts
@@ -87,12 +87,12 @@ describe('deployment', () => {
     nock(aiCoreDestination.url, {
       reqheaders: {
         'AI-Resource-Group': 'default',
-        'Authentication': 'test-auth'
+        Authentication: 'test-auth'
       }
     })
       .post('/v2/lm/deployments')
       .reply(200, expectedResponse, {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json'
       });
 
     const deploymentPostData: AiDeploymentCreationRequest = {
@@ -102,7 +102,9 @@ describe('deployment', () => {
     const result: AiDeploymentCreationResponse =
       await DeploymentApi.deploymentCreate(deploymentPostData, {
         'AI-Resource-Group': 'default'
-      }).addCustomHeaders({'Authentication': 'test-auth'}).execute();
+      })
+        .addCustomHeaders({ Authentication: 'test-auth' })
+        .execute();
 
     expect(result).toEqual(expectedResponse);
   });

--- a/packages/ai-api/src/tests/deployment-api.test.ts
+++ b/packages/ai-api/src/tests/deployment-api.test.ts
@@ -76,7 +76,7 @@ describe('deployment', () => {
     expect(result).toEqual(expectedResponse);
   });
 
-  it('parses a successful response for post request', async () => {
+  it('parses a successful response for post request with required headers', async () => {
     const expectedResponse: AiDeploymentCreationResponse = {
       deploymentUrl: '',
       id: '4e5f6g7h',
@@ -87,7 +87,9 @@ describe('deployment', () => {
     nock(aiCoreDestination.url, {
       reqheaders: {
         'AI-Resource-Group': 'default',
-        Authentication: 'test-auth'
+        'some-test-header': 'test-header-value',
+        'content-type': 'application/json',
+        'ai-client-type': 'AI SD JavaScript'
       }
     })
       .post('/v2/lm/deployments')
@@ -103,7 +105,7 @@ describe('deployment', () => {
       await DeploymentApi.deploymentCreate(deploymentPostData, {
         'AI-Resource-Group': 'default'
       })
-        .addCustomHeaders({ Authentication: 'test-auth' })
+        .addCustomHeaders({ 'some-test-header': 'test-header-value' })
         .execute();
 
     expect(result).toEqual(expectedResponse);

--- a/packages/ai-api/src/tests/deployment-api.test.ts
+++ b/packages/ai-api/src/tests/deployment-api.test.ts
@@ -86,12 +86,13 @@ describe('deployment', () => {
 
     nock(aiCoreDestination.url, {
       reqheaders: {
-        'AI-Resource-Group': 'default'
+        'AI-Resource-Group': 'default',
+        'Authentication': 'test-auth'
       }
     })
       .post('/v2/lm/deployments')
       .reply(200, expectedResponse, {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       });
 
     const deploymentPostData: AiDeploymentCreationRequest = {
@@ -101,7 +102,7 @@ describe('deployment', () => {
     const result: AiDeploymentCreationResponse =
       await DeploymentApi.deploymentCreate(deploymentPostData, {
         'AI-Resource-Group': 'default'
-      }).execute();
+      }).addCustomHeaders({'Authentication': 'test-auth'}).execute();
 
     expect(result).toEqual(expectedResponse);
   });

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -102,13 +102,7 @@ function mergeWithDefaultRequestConfig(
   return {
     ...defaultConfig,
     ...requestConfig,
-    headers: mergeIgnoreCase(
-      defaultConfig.headers,
-      requestConfig?.headers
-    ),
-    params: mergeIgnoreCase(
-      defaultConfig.params,
-      requestConfig?.params
-    )
+    headers: mergeIgnoreCase(defaultConfig.headers, requestConfig?.headers),
+    params: mergeIgnoreCase(defaultConfig.params, requestConfig?.params)
   };
 }

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -102,13 +102,13 @@ function mergeWithDefaultRequestConfig(
   return {
     ...defaultConfig,
     ...requestConfig,
-    headers: mergeIgnoreCase({
-      ...defaultConfig.headers,
-      ...requestConfig?.headers
-    }),
-    params: mergeIgnoreCase({
-      ...defaultConfig.params,
-      ...requestConfig?.params
-    })
+    headers: mergeIgnoreCase(
+      defaultConfig.headers,
+      requestConfig?.headers
+    ),
+    params: mergeIgnoreCase(
+      defaultConfig.params,
+      requestConfig?.params
+    )
   };
 }

--- a/packages/core/src/openapi-request-builder.ts
+++ b/packages/core/src/openapi-request-builder.ts
@@ -28,7 +28,15 @@ export class OpenApiRequestBuilder<
     const { url, data, ...rest } = await this.requestConfig();
     // TODO: Remove explicit url! once we updated the type in the Cloud SDK, since url is always defined.
     return executeRequest({ url: url! }, data, {
-      ...rest
+      ...rest,
+      headers: {
+        ...rest.headers?.requestConfig,
+        ...rest.headers?.custom
+      },
+      params: {
+        ...rest.params?.requestConfig,
+        ...rest.params?.custom
+      }
     });
   }
 


### PR DESCRIPTION
## Context

The ai-api clients use the OpenAPI req builders which uses `HttpRequestConfigWithOrigin`. The `executeRequest` and `mergeWithDefaultRequestConfig` on the other hand expect `HttpRequestConfig` which causes incorrect/incomplete headers and params to be sent.

## Definition of Done

- [x] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated