### PR TITLE
revert: "chore: remove grounding types from indext.ts"

### DIFF
--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -10,6 +10,8 @@ export type {
   MaskingProviderConfig,
   LlmModuleResult,
   LlmChoice,
+  GroundingModuleConfig,
+  GroundingFilter,
   GenericModuleResult,
   FilteringModuleConfig,
   FilteringConfig,


### PR DESCRIPTION
Reverts SAP/ai-sdk-js#146

The original PR build was not successful.