### PR TITLE
chore: Update github actions as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    target-branch: main
     directory: '/'
     schedule:
       interval: daily
@@ -15,3 +14,9 @@ updates:
     groups:
       sap-cloud-sdk:
         patterns: ['@sap-cloud-sdk/*']
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      time: '01:00'
+      timezone: 'Europe/Berlin'


### PR DESCRIPTION
Currently dependabot only updates npm dependencies, but not github actions. This should fix that.