### PR TITLE
chore: Remove eslint workaround

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,14 +20,14 @@ export default [
       '**/*.d.ts',
       '**/dist/**/*',
       '**/coverage/**/*',
-      'packages/ai-api/src/client/**/*',
-      'packages/foundation-models/src/azure-openai/client/inference/schema/on-your-data-system-assigned-managed-identity-authentication-options.ts',
+      'packages/ai-api/src/client/**/*'
     ]
   },
   {
     files: [
       '**/test-util/**/*.ts',
       '**/packages/orchestration/src/client/**/*',
+      '**/packages/foundation-models/src/azure-openai/client/**/*',
       '**/*.zod.ts'
     ],
     rules: {
@@ -44,6 +44,12 @@ export default [
     files: ['packages/foundation-models/src/azure-openai/client/inference/schema/*.ts'],
     rules: {
       'jsdoc/check-indentation': 'off'
+    }
+  },
+  {
+    files: ['packages/**/*/schema/*.ts'],
+    rules: {
+      '@typescript-eslint/consistent-type-definitions': 'off'
     }
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,8 +26,7 @@ export default [
   {
     files: [
       '**/test-util/**/*.ts',
-      '**/packages/orchestration/src/client/**/*',
-      '**/packages/foundation-models/src/azure-openai/client/**/*',
+      '**/packages/**/client/**/*',
       '**/*.zod.ts'
     ],
     rules: {
@@ -47,7 +46,7 @@ export default [
     }
   },
   {
-    files: ['packages/**/*/schema/*.ts'],
+    files: ['**/packages/**/client/**/*.ts'],
     rules: {
       '@typescript-eslint/consistent-type-definitions': 'off'
     }


### PR DESCRIPTION
## Context

`@typescript-eslint/consistent-type-definitions` converts generated types (which don't have `& Record<string, any>`) to interfaces
- This rule is now turned off for generated schema code
- The jsdoc/require-jsdoc is turned off for generated code (across all packages) as well

## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated