### PR TITLE
chore: Add openai response tests

### DIFF
--- a/.changeset/famous-needles-act.md
+++ b/.changeset/famous-needles-act.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/foundation-models': patch
+---
+
+[Fixed Issue] Fix index-based data access in embedding response. Previously, the 0th index data was always returned.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "smoke-tests": "pnpm -F=@sap-ai-sdk/smoke-tests",
     "schema-tests": "pnpm -F=@sap-ai-sdk/schema-tests",
     "check:public-api": "pnpm -r check:public-api",
-    "check:deps": "pnpm -r -F !./tests/smoke-tests -F !./tests/schema-tests exec depcheck --ignores nock --quiet"
+    "check:deps": "pnpm -r -F !./tests/smoke-tests -F !./tests/schema-tests exec depcheck --ignores=\"nock,@jest/globals\" --quiet"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.8",

--- a/packages/foundation-models/src/azure-openai/azure-openai-chat-completion-response.test.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-chat-completion-response.test.ts
@@ -1,7 +1,8 @@
+import { createLogger } from '@sap-cloud-sdk/util';
 import { parseMockResponse } from '../../../../test-util/mock-http.js';
 import { AzureOpenAiChatCompletionResponse } from './azure-openai-chat-completion-response.js';
 import { AzureOpenAiCreateChatCompletionResponse } from './client/inference/schema/index.js';
-
+import { jest } from '@jest/globals';
 describe('OpenAI chat completion response', () => {
   const mockResponse =
     parseMockResponse<AzureOpenAiCreateChatCompletionResponse>(
@@ -14,9 +15,42 @@ describe('OpenAI chat completion response', () => {
     headers: {},
     request: {}
   };
-  const response = new AzureOpenAiChatCompletionResponse(rawResponse);
+  const azureOpenAiChatResponse = new AzureOpenAiChatCompletionResponse(rawResponse);
 
-  it('should return the completion response', () => {
-    expect(response.data).toStrictEqual(mockResponse);
+  it('should return the chat completion response', () => {
+    expect(azureOpenAiChatResponse.data).toStrictEqual(mockResponse);
+  });
+
+  it('should return raw response', () => {
+    expect(azureOpenAiChatResponse.rawResponse).toBe(rawResponse);
+  });
+
+  it('should get token usage', () => {
+    expect(azureOpenAiChatResponse.getTokenUsage()).toMatchObject({
+      completion_tokens: expect.any(Number),
+      prompt_tokens: expect.any(Number),
+      total_tokens: expect.any(Number)
+    });
+  });
+
+  it('should return default choice index with convenience functions', () => {
+    expect(azureOpenAiChatResponse.getFinishReason()).toBe('stop');
+    expect(azureOpenAiChatResponse.getContent()).toBe(
+      'Hello! I\'m just a computer program, so I don\'t have feelings, but thanks for asking. How can I assist you today?'
+    );
+  });
+
+  it('should return undefined when convenience function is called with incorrect index', () => {
+    const logger = createLogger({
+      package: 'foundation-models',
+      messageContext: 'azure-openai-chat-completion-response'
+    });
+    const errorSpy = jest.spyOn(logger, 'error');
+    expect(azureOpenAiChatResponse.getFinishReason(1)).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Choice index 1 is out of bounds."
+    );
+    expect(azureOpenAiChatResponse.getContent(1)).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/foundation-models/src/azure-openai/azure-openai-chat-completion-response.test.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-chat-completion-response.test.ts
@@ -1,8 +1,8 @@
 import { createLogger } from '@sap-cloud-sdk/util';
+import { jest } from '@jest/globals';
 import { parseMockResponse } from '../../../../test-util/mock-http.js';
 import { AzureOpenAiChatCompletionResponse } from './azure-openai-chat-completion-response.js';
 import { AzureOpenAiCreateChatCompletionResponse } from './client/inference/schema/index.js';
-import { jest } from '@jest/globals';
 describe('OpenAI chat completion response', () => {
   const mockResponse =
     parseMockResponse<AzureOpenAiCreateChatCompletionResponse>(
@@ -15,7 +15,9 @@ describe('OpenAI chat completion response', () => {
     headers: {},
     request: {}
   };
-  const azureOpenAiChatResponse = new AzureOpenAiChatCompletionResponse(rawResponse);
+  const azureOpenAiChatResponse = new AzureOpenAiChatCompletionResponse(
+    rawResponse
+  );
 
   it('should return the chat completion response', () => {
     expect(azureOpenAiChatResponse.data).toStrictEqual(mockResponse);
@@ -36,7 +38,7 @@ describe('OpenAI chat completion response', () => {
   it('should return default choice index with convenience functions', () => {
     expect(azureOpenAiChatResponse.getFinishReason()).toBe('stop');
     expect(azureOpenAiChatResponse.getContent()).toBe(
-      'Hello! I\'m just a computer program, so I don\'t have feelings, but thanks for asking. How can I assist you today?'
+      "Hello! I'm just a computer program, so I don't have feelings, but thanks for asking. How can I assist you today?"
     );
   });
 
@@ -47,9 +49,7 @@ describe('OpenAI chat completion response', () => {
     });
     const errorSpy = jest.spyOn(logger, 'error');
     expect(azureOpenAiChatResponse.getFinishReason(1)).toBeUndefined();
-    expect(errorSpy).toHaveBeenCalledWith(
-      "Choice index 1 is out of bounds."
-    );
+    expect(errorSpy).toHaveBeenCalledWith('Choice index 1 is out of bounds.');
     expect(azureOpenAiChatResponse.getContent(1)).toBeUndefined();
     expect(errorSpy).toHaveBeenCalledTimes(2);
   });

--- a/packages/foundation-models/src/azure-openai/azure-openai-embedding-response.test.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-embedding-response.test.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@sap-cloud-sdk/util';
+import { jest } from '@jest/globals';
 import { parseMockResponse } from '../../../../test-util/mock-http.js';
 import { AzureOpenAiEmbeddingResponse } from './azure-openai-embedding-response.js';
-import { jest } from '@jest/globals';
 
 describe('Azure OpenAI embedding response', () => {
   const mockResponse = parseMockResponse<AzureOpenAiEmbeddingResponse>(
@@ -25,14 +25,12 @@ describe('Azure OpenAI embedding response', () => {
   });
   it('should return undefined when convenience function is called with incorrect index', () => {
     const logger = createLogger({
-package: 'foundation-models',
-  messageContext: 'azure-openai-embedding-response'
+      package: 'foundation-models',
+      messageContext: 'azure-openai-embedding-response'
     });
     const errorSpy = jest.spyOn(logger, 'error');
     expect(embeddingResponse.getEmbedding(1)).toBeUndefined();
-    expect(errorSpy).toHaveBeenCalledWith(
-      "Data index 1 is out of bounds."
-    );
+    expect(errorSpy).toHaveBeenCalledWith('Data index 1 is out of bounds.');
     expect(errorSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/foundation-models/src/azure-openai/azure-openai-embedding-response.test.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-embedding-response.test.ts
@@ -1,5 +1,7 @@
+import { createLogger } from '@sap-cloud-sdk/util';
 import { parseMockResponse } from '../../../../test-util/mock-http.js';
 import { AzureOpenAiEmbeddingResponse } from './azure-openai-embedding-response.js';
+import { jest } from '@jest/globals';
 
 describe('Azure OpenAI embedding response', () => {
   const mockResponse = parseMockResponse<AzureOpenAiEmbeddingResponse>(
@@ -12,9 +14,25 @@ describe('Azure OpenAI embedding response', () => {
     headers: {},
     request: {}
   };
-  const response = new AzureOpenAiEmbeddingResponse(rawResponse);
+  const embeddingResponse = new AzureOpenAiEmbeddingResponse(rawResponse);
 
   it('should return the embedding response', () => {
-    expect(response.data).toStrictEqual(mockResponse);
+    expect(embeddingResponse.data).toStrictEqual(mockResponse);
+  });
+
+  it('should return raw response', () => {
+    expect(embeddingResponse.rawResponse).toBe(rawResponse);
+  });
+  it('should return undefined when convenience function is called with incorrect index', () => {
+    const logger = createLogger({
+package: 'foundation-models',
+  messageContext: 'azure-openai-embedding-response'
+    });
+    const errorSpy = jest.spyOn(logger, 'error');
+    expect(embeddingResponse.getEmbedding(1)).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Data index 1 is out of bounds."
+    );
+    expect(errorSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/foundation-models/src/azure-openai/azure-openai-embedding-response.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-embedding-response.ts
@@ -27,7 +27,7 @@ export class AzureOpenAiEmbeddingResponse {
    */
   getEmbedding(dataIndex = 0): number[] | undefined {
     this.logInvalidDataIndex(dataIndex);
-    return this.data.data[0]?.embedding;
+    return this.data.data[dataIndex]?.embedding;
   }
 
   private logInvalidDataIndex(dataIndex: number): void {

--- a/packages/orchestration/src/orchestration-response.test.ts
+++ b/packages/orchestration/src/orchestration-response.test.ts
@@ -1,6 +1,8 @@
-import { parseMockResponse } from '../../../test-util/mock-http';
+import { createLogger } from '@sap-cloud-sdk/util';
+import { parseMockResponse } from '../../../test-util/mock-http.js';
 import { CompletionPostResponse } from './client/api/schema/index.js';
-import { OrchestrationResponse } from './orchestration-response';
+import { OrchestrationResponse } from './orchestration-response.js';
+import { jest } from '@jest/globals';
 
 describe('OrchestrationResponse', () => {
   const mockResponse = parseMockResponse<CompletionPostResponse>(
@@ -39,8 +41,17 @@ describe('OrchestrationResponse', () => {
   });
 
   it('should return undefined when convenience function is called with incorrect index', () => {
+    const logger = createLogger({
+      package: 'orchestration',
+      messageContext: 'orchestration-response'
+   });
+   const errorSpy = jest.spyOn(logger, 'error');
     expect(orchestrationResponse.getFinishReason(1)).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Choice index 1 is out of bounds."
+    );
     expect(orchestrationResponse.getContent(1)).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should throw if content that was filtered is accessed', () => {

--- a/packages/orchestration/src/orchestration-response.test.ts
+++ b/packages/orchestration/src/orchestration-response.test.ts
@@ -1,8 +1,8 @@
 import { createLogger } from '@sap-cloud-sdk/util';
+import { jest } from '@jest/globals';
 import { parseMockResponse } from '../../../test-util/mock-http.js';
 import { CompletionPostResponse } from './client/api/schema/index.js';
 import { OrchestrationResponse } from './orchestration-response.js';
-import { jest } from '@jest/globals';
 
 describe('OrchestrationResponse', () => {
   const mockResponse = parseMockResponse<CompletionPostResponse>(
@@ -44,12 +44,10 @@ describe('OrchestrationResponse', () => {
     const logger = createLogger({
       package: 'orchestration',
       messageContext: 'orchestration-response'
-   });
-   const errorSpy = jest.spyOn(logger, 'error');
+    });
+    const errorSpy = jest.spyOn(logger, 'error');
     expect(orchestrationResponse.getFinishReason(1)).toBeUndefined();
-    expect(errorSpy).toHaveBeenCalledWith(
-      "Choice index 1 is out of bounds."
-    );
+    expect(errorSpy).toHaveBeenCalledWith('Choice index 1 is out of bounds.');
     expect(orchestrationResponse.getContent(1)).toBeUndefined();
     expect(errorSpy).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## Context

AI/gen-ai-hub-sdk-js-backlog#143.

Add more test. I also noticed a bug in the convenience method in embedding response class. 

## Definition of Done

- [x] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated