### PR TITLE
chore: Fix resource group header

### DIFF
--- a/.changeset/two-bottles-juggle.md
+++ b/.changeset/two-bottles-juggle.md
@@ -1,0 +1,9 @@
+---
+'@sap-ai-sdk/foundation-models': minor
+'@sap-ai-sdk/orchestration': minor
+'@sap-ai-sdk/langchain': minor
+'@sap-ai-sdk/ai-api': minor
+'@sap-ai-sdk/core': minor
+---
+
+[Fixed Issue] Fix sending the correct resource group headers when custom resource group is set.

--- a/packages/ai-api/src/utils/deployment-resolver.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.ts
@@ -51,7 +51,9 @@ export type ModelDeployment<ModelNameT = string> =
 /**
  * @internal
  */
-export function getResourceGroup(modelDeployment: ModelDeployment): string | undefined {
+export function getResourceGroup(
+  modelDeployment: ModelDeployment
+): string | undefined {
   return typeof modelDeployment === 'object'
     ? modelDeployment.resourceGroup
     : undefined;

--- a/packages/ai-api/src/utils/deployment-resolver.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.ts
@@ -49,6 +49,15 @@ export type ModelDeployment<ModelNameT = string> =
   | ((ModelConfig<ModelNameT> | DeploymentIdConfig) & ResourceGroupConfig);
 
 /**
+ * @internal
+ */
+export function getResourceGroup(modelDeployment: ModelDeployment): string | undefined {
+  return typeof modelDeployment === 'object'
+    ? modelDeployment.resourceGroup
+    : undefined;
+}
+
+/**
  * Type guard to check if the given deployment configuration is a deployment ID configuration.
  * @param modelDeployment - Configuration to check.
  * @returns `true` if the configuration is a deployment ID configuration, `false` otherwise.

--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -36,4 +36,27 @@ describe('http-client', () => {
     expect(res.status).toBe(200);
     expect(res.data).toEqual(mockPromptResponse);
   }, 10000);
+
+  it('should execute a request to the AI Core service with a custom resource gorup', async () => {
+    const mockPrompt = { prompt: 'some test prompt' };
+    const mockPromptResponse = { completion: 'some test completion' };
+
+    const scope = nock(aiCoreDestination.url, {
+      reqheaders: {
+        'ai-resource-group': 'custom-resource-group',
+        'ai-client-type': 'AI SDK JavaScript'
+      }
+    })
+      .post('/v2/some/endpoint', mockPrompt)
+      .query({ 'api-version': 'mock-api-version' })
+      .reply(200, mockPromptResponse);
+
+    const res = await executeRequest(
+      { url: '/some/endpoint', apiVersion: 'mock-api-version', resourceGroup: 'custom-resource-group' },
+      mockPrompt
+    );
+    expect(scope.isDone()).toBe(true);
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual(mockPromptResponse);
+  });
 });

--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -52,7 +52,11 @@ describe('http-client', () => {
       .reply(200, mockPromptResponse);
 
     const res = await executeRequest(
-      { url: '/some/endpoint', apiVersion: 'mock-api-version', resourceGroup: 'custom-resource-group' },
+      {
+        url: '/some/endpoint',
+        apiVersion: 'mock-api-version',
+        resourceGroup: 'custom-resource-group'
+      },
       mockPrompt
     );
     expect(scope.isDone()).toBe(true);

--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -37,7 +37,7 @@ describe('http-client', () => {
     expect(res.data).toEqual(mockPromptResponse);
   }, 10000);
 
-  it('should execute a request to the AI Core service with a custom resource gorup', async () => {
+  it('should execute a request to the AI Core service with a custom resource group', async () => {
     const mockPrompt = { prompt: 'some test prompt' };
     const mockPromptResponse = { completion: 'some test completion' };
 

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -52,7 +52,7 @@ export async function executeRequest(
   requestConfig?: CustomRequestConfig
 ): Promise<HttpResponse> {
   const aiCoreDestination = await getAiCoreDestination();
-  const { url, apiVersion, resourceGroup } = endpointOptions;
+  const { url, apiVersion, resourceGroup = 'default' } = endpointOptions;
 
   const mergedRequestConfig = {
     ...mergeWithDefaultRequestConfig(apiVersion, resourceGroup, requestConfig),
@@ -79,7 +79,7 @@ function mergeWithDefaultRequestConfig(
     method: 'post',
     headers: {
       'content-type': 'application/json',
-      'ai-resource-group': resourceGroup ?? 'default',
+      'ai-resource-group': resourceGroup,
       'ai-client-type': 'AI SDK JavaScript'
     },
     params: apiVersion ? { 'api-version': apiVersion } : {}

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -30,11 +30,14 @@ export interface EndpointOptions {
    * The specific endpoint to call.
    */
   url: string;
-
   /**
    * The API version to use.
    */
   apiVersion?: string;
+  /**
+   * The resource group to use.
+   */
+  resourceGroup?: string;
 }
 /**
  * Executes a request to the AI Core service.
@@ -49,10 +52,10 @@ export async function executeRequest(
   requestConfig?: CustomRequestConfig
 ): Promise<HttpResponse> {
   const aiCoreDestination = await getAiCoreDestination();
-  const { url, apiVersion } = endpointOptions;
+  const { url, apiVersion, resourceGroup } = endpointOptions;
 
   const mergedRequestConfig = {
-    ...mergeWithDefaultRequestConfig(apiVersion, requestConfig),
+    ...mergeWithDefaultRequestConfig(apiVersion, resourceGroup, requestConfig),
     data: JSON.stringify(data)
   };
 
@@ -69,13 +72,14 @@ export async function executeRequest(
 
 function mergeWithDefaultRequestConfig(
   apiVersion?: string,
+  resourceGroup?: string,
   requestConfig?: CustomRequestConfig
 ): HttpRequestConfig {
   const defaultConfig: HttpRequestConfig = {
     method: 'post',
     headers: {
       'content-type': 'application/json',
-      'ai-resource-group': 'default',
+      'ai-resource-group': resourceGroup ?? 'default',
       'ai-client-type': 'AI SDK JavaScript'
     },
     params: apiVersion ? { 'api-version': apiVersion } : {}

--- a/packages/foundation-models/src/azure-openai/azure-openai-chat-client.test.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-chat-client.test.ts
@@ -15,7 +15,7 @@ describe('Azure OpenAI chat client', () => {
     apiVersion
   };
 
-  const client = new AzureOpenAiChatClient({ modelName: 'gpt-35-turbo' });
+  const client = new AzureOpenAiChatClient({ deploymentId: '1234' });
 
   beforeEach(() => {
     mockClientCredentialsGrantCall();

--- a/packages/foundation-models/src/azure-openai/azure-openai-chat-client.test.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-chat-client.test.ts
@@ -76,7 +76,7 @@ describe('Azure OpenAI chat client', () => {
     await expect(client.run(prompt)).rejects.toThrow('status code 400');
   });
 
-  it('executes a request with the custom request group', async () => {
+  it('executes a request with the custom resource group', async () => {
     const customChatCompletionEndpoint = {
       url: 'inference/deployments/1234/chat/completions',
       apiVersion,
@@ -118,7 +118,7 @@ describe('Azure OpenAI chat client', () => {
     expect(response.data).toEqual(mockResponse);
   });
 
-  it('it fails when the wrong resource group is set', async () => {
+  it('fails when the wrong resource group is set', async () => {
     const customChatCompletionEndpoint = {
       url: 'inference/deployments/1234/chat/completions',
       apiVersion,

--- a/packages/foundation-models/src/azure-openai/azure-openai-chat-client.test.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-chat-client.test.ts
@@ -84,10 +84,10 @@ describe('Azure OpenAI chat client', () => {
     };
 
     const mockResponse =
-    parseMockResponse<AzureOpenAiCreateChatCompletionResponse>(
-      'foundation-models',
-      'azure-openai-chat-completion-success-response.json'
-    );
+      parseMockResponse<AzureOpenAiCreateChatCompletionResponse>(
+        'foundation-models',
+        'azure-openai-chat-completion-success-response.json'
+      );
 
     const prompt = {
       messages: [
@@ -135,10 +135,10 @@ describe('Azure OpenAI chat client', () => {
     };
 
     const mockResponse =
-    parseMockResponse<AzureOpenAiCreateChatCompletionResponse>(
-      'foundation-models',
-      'azure-openai-chat-completion-success-response.json'
-    );
+      parseMockResponse<AzureOpenAiCreateChatCompletionResponse>(
+        'foundation-models',
+        'azure-openai-chat-completion-success-response.json'
+      );
 
     mockInference(
       {

--- a/packages/foundation-models/src/azure-openai/azure-openai-chat-client.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-chat-client.ts
@@ -1,6 +1,7 @@
 import { type CustomRequestConfig, executeRequest } from '@sap-ai-sdk/core';
 import {
   getDeploymentId,
+  getResourceGroup,
   type ModelDeployment
 } from '@sap-ai-sdk/ai-api/internal.js';
 import type { AzureOpenAiCreateChatCompletionRequest } from './client/inference/schema/index.js';
@@ -31,10 +32,12 @@ export class AzureOpenAiChatClient {
       this.modelDeployment,
       'azure-openai'
     );
+    const resourceGroup = getResourceGroup(this.modelDeployment);
     const response = await executeRequest(
       {
         url: `/inference/deployments/${deploymentId}/chat/completions`,
-        apiVersion
+        apiVersion,
+        resourceGroup
       },
       data,
       requestConfig

--- a/packages/foundation-models/src/azure-openai/azure-openai-embedding-client.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-embedding-client.ts
@@ -1,6 +1,7 @@
 import { type CustomRequestConfig, executeRequest } from '@sap-ai-sdk/core';
 import {
   getDeploymentId,
+  getResourceGroup,
   type ModelDeployment
 } from '@sap-ai-sdk/ai-api/internal.js';
 import { AzureOpenAiEmbeddingResponse } from './azure-openai-embedding-response.js';
@@ -34,8 +35,9 @@ export class AzureOpenAiEmbeddingClient {
       this.modelDeployment,
       'azure-openai'
     );
+    const resourceGroup = getResourceGroup(this.modelDeployment);
     const response = await executeRequest(
-      { url: `/inference/deployments/${deploymentId}/embeddings`, apiVersion },
+      { url: `/inference/deployments/${deploymentId}/embeddings`, apiVersion, resourceGroup },
       data,
       requestConfig
     );

--- a/packages/foundation-models/src/azure-openai/azure-openai-embedding-client.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-embedding-client.ts
@@ -37,7 +37,11 @@ export class AzureOpenAiEmbeddingClient {
     );
     const resourceGroup = getResourceGroup(this.modelDeployment);
     const response = await executeRequest(
-      { url: `/inference/deployments/${deploymentId}/embeddings`, apiVersion, resourceGroup },
+      {
+        url: `/inference/deployments/${deploymentId}/embeddings`,
+        apiVersion,
+        resourceGroup
+      },
       data,
       requestConfig
     );

--- a/packages/langchain/src/openai/chat.ts
+++ b/packages/langchain/src/openai/chat.ts
@@ -3,7 +3,6 @@ import { BaseMessage } from '@langchain/core/messages';
 import type { ChatResult } from '@langchain/core/outputs';
 import { AzureOpenAiChatClient as AzureOpenAiChatClientBase } from '@sap-ai-sdk/foundation-models';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import { AzureOpenAiChatModel } from '@sap-ai-sdk/core';
 import { mapLangchainToAiClient, mapOutputToChatResult } from './util.js';
 import type {
   AzureOpenAiChatCallOptions,
@@ -13,13 +12,7 @@ import type {
 /**
  * LangChain chat client for Azure OpenAI consumption on SAP BTP.
  */
-export class AzureOpenAiChatClient
-  extends BaseChatModel<AzureOpenAiChatCallOptions>
-  implements AzureOpenAiChatModelParams
-{
-  modelName: AzureOpenAiChatModel;
-  modelVersion?: string;
-  resourceGroup?: string;
+export class AzureOpenAiChatClient extends BaseChatModel<AzureOpenAiChatCallOptions> {
   temperature?: number | null;
   top_p?: number | null;
   logit_bias?: Record<string, any> | null | undefined;
@@ -33,9 +26,6 @@ export class AzureOpenAiChatClient
   constructor(fields: AzureOpenAiChatModelParams) {
     super(fields);
     this.openAiChatClient = new AzureOpenAiChatClientBase(fields);
-    this.modelName = fields.modelName;
-    this.modelVersion = fields.modelVersion;
-    this.resourceGroup = fields.resourceGroup;
     this.temperature = fields.temperature;
     this.top_p = fields.top_p;
     this.logit_bias = fields.logit_bias;

--- a/packages/langchain/src/openai/embedding.ts
+++ b/packages/langchain/src/openai/embedding.ts
@@ -9,10 +9,7 @@ import { AzureOpenAiEmbeddingModelParams } from './types.js';
 /**
  * LangChain embedding client for Azure OpenAI consumption on SAP BTP.
  */
-export class AzureOpenAiEmbeddingClient
-  extends Embeddings
-  implements AzureOpenAiEmbeddingModelParams
-{
+export class AzureOpenAiEmbeddingClient extends Embeddings {
   modelName: AzureOpenAiEmbeddingModel;
   modelVersion?: string;
   resourceGroup?: string;

--- a/packages/orchestration/src/orchestration-client.ts
+++ b/packages/orchestration/src/orchestration-client.ts
@@ -39,7 +39,8 @@ export class OrchestrationClient {
 
     const response = await executeRequest(
       {
-        url: `/inference/deployments/${deploymentId}/completion`
+        url: `/inference/deployments/${deploymentId}/completion`,
+        resourceGroup: this.deploymentConfig?.resourceGroup
       },
       body,
       requestConfig

--- a/test-util/mock-http.ts
+++ b/test-util/mock-http.ts
@@ -99,11 +99,11 @@ export function mockInference(
   },
   endpoint: EndpointOptions = mockEndpoint
 ): nock.Scope {
-  const { url, apiVersion } = endpoint;
+  const { url, apiVersion, resourceGroup } = endpoint;
   const destination = getMockedAiCoreDestination();
   return nock(destination.url, {
     reqheaders: {
-      'ai-resource-group': 'default',
+      'ai-resource-group': resourceGroup ?? 'default',
       authorization: `Bearer ${destination.authTokens?.[0].value}`
     }
   })

--- a/test-util/mock-http.ts
+++ b/test-util/mock-http.ts
@@ -99,11 +99,11 @@ export function mockInference(
   },
   endpoint: EndpointOptions = mockEndpoint
 ): nock.Scope {
-  const { url, apiVersion, resourceGroup } = endpoint;
+  const { url, apiVersion, resourceGroup = 'default' } = endpoint;
   const destination = getMockedAiCoreDestination();
   return nock(destination.url, {
     reqheaders: {
-      'ai-resource-group': resourceGroup ?? 'default',
+      'ai-resource-group': resourceGroup,
       authorization: `Bearer ${destination.authTokens?.[0].value}`
     }
   })


### PR DESCRIPTION
## Context

AI/gen-ai-hub-sdk-js-backlog#146.

A user discovered a bug where we do not properly set the resource group after they have set it in the client's initialization.

With this fix, this should be fixed.

## Definition of Done

- [x] Code is tested (Unit, E2E)
- [x] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated