### PR TITLE
docs: Fixed broken link on api-ai README

### DIFF
--- a/packages/ai-api/README.md
+++ b/packages/ai-api/README.md
@@ -43,7 +43,7 @@ To ensure compatibility and manage updates effectively, we strongly recommend us
 
 ## Prerequisites
 
-- [Enable the AI Core service in BTP](https://help.sap.com/docs/sap-ai-api/sap-ai-api-service-guide/initial-setup).
+- [Enable the AI Core service in BTP](https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/initial-setup).
 - Project configured with Node.js v20 or higher and native ESM support enabled.
 
 ## Usage


### PR DESCRIPTION
## Context

Updated broken link on the api-ai `README.md`.
I assumed the proper link was the same as in the corresponding link used in the other packages.

## Definition of Done

- N/A - Code is tested (Unit, E2E)
- N/A - Error handling created / updated & covered by the tests above
- [x] Documentation updated
- N/A - (Optional) Aligned changes with the Java SDK
- N/A - (Optional) Release notes updated