### PR TITLE
chore: Add typescript as dev dependency in sub packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ build/Release
 .vscode
 /pnpm-publish-summary.json
 /tests/smoke-tests/deployment
+.idea

--- a/packages/foundation-models/package.json
+++ b/packages/foundation-models/package.json
@@ -35,5 +35,8 @@
     "@sap-ai-sdk/core": "workspace:^",
     "@sap-cloud-sdk/http-client": "^3.22.2",
     "@sap-cloud-sdk/util": "^3.22.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,10 @@ importers:
       '@sap-cloud-sdk/util':
         specifier: ^3.22.2
         version: 3.22.2
+    devDependencies:
+      typescript:
+        specifier: ^5.6.3
+        version: 5.6.3
 
   packages/langchain:
     dependencies:


### PR DESCRIPTION
Without adding this, I have an error `MODULE_NOT_FOUND`, when running `pnpm install --frozen-lockfile` on my command line with node 20.

I'll add it to all packages when approved.