### PR TITLE
fix: Wrong endpoint in smoke test

### DIFF
--- a/tests/smoke-tests/test/smoke.test.ts
+++ b/tests/smoke-tests/test/smoke.test.ts
@@ -3,7 +3,7 @@ const smokeTestRoute =
 describe('Smoke Test', () => {
   it('aicore client retrieves a list of deployments', async () => {
     await expect(
-      fetch(`${smokeTestRoute}/ai-api/get-deployments`)
+      fetch(`${smokeTestRoute}/ai-api/deployments`)
     ).resolves.toHaveProperty('status', 200);
   });
 


### PR DESCRIPTION
## Context

Fixes failing smoke test run, wrong API endpoint used for testing, `/ai-api/get-deployments` instead of `/ai-api/deployments`

## Definition of Done

- [x] Code is tested (Unit, E2E)
- ~[ ] Error handling created / updated & covered by the tests above~
- ~[ ] Documentation updated~
- ~[ ] (Optional) Aligned changes with the Java SDK~
- ~[ ] (Optional) Release notes updated~