### PR TITLE
fix: Make `CustomRequestConfig` properties partially picked

### DIFF
--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -9,16 +9,18 @@ import type {
 /**
  * The type for parameters in custom request configuration.
  */
-export type CustomRequestConfig = Pick<
-  HttpRequestConfig,
-  | 'headers'
-  | 'params'
-  | 'middleware'
-  | 'maxContentLength'
-  | 'proxy'
-  | 'httpAgent'
-  | 'httpsAgent'
-  | 'parameterEncoder'
+export type CustomRequestConfig = Partial<
+  Pick<
+    HttpRequestConfig,
+    | 'headers'
+    | 'params'
+    | 'middleware'
+    | 'maxContentLength'
+    | 'proxy'
+    | 'httpAgent'
+    | 'httpsAgent'
+    | 'parameterEncoder'
+  >
 > &
   Record<string, any>;
 


### PR DESCRIPTION
## Context

AI/gen-ai-hub-sdk-js-backlog#ISSUENUMBER.

Typescript complains the following code before:

```ts
customRequestConfig = { ...customRequestConfig, somePropery: 'someValue' };
```

Add `Partial<...>` for `CustomRequestConfig`. Otherwise, properties are picked and **required**.

## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated