### PR TITLE
chore: Update RAG langchain test

### DIFF
--- a/tests/e2e-tests/src/open-ai-langchain.test.ts
+++ b/tests/e2e-tests/src/open-ai-langchain.test.ts
@@ -16,6 +16,6 @@ describe('Langchain OpenAI Access', () => {
 
   it('executes an invoke based on an embedding vector from our orchestration readme', async () => {
     const result = await invokeRagChain();
-    expect(result).toContain('@sap-ai-sdk/orchestration');
+    expect(result).toContain('OrchestrationClient');
   });
 });


### PR DESCRIPTION
## Context

The RAG langchain test is currently flaky due to the string we test for not always being part of the response.
As the prompt clearly asks for "code examples", at least the instantiation of the class being part of the response is a reasonable assumption, therefore we now test for the response to include the class name of the orchestration client.