### PR TITLE
chore: Make outputfilter test less flaky

### DIFF
--- a/sample-code/src/orchestration.ts
+++ b/sample-code/src/orchestration.ts
@@ -123,12 +123,11 @@ export async function orchestrationOutputFiltering(): Promise<OrchestrationRespo
     messagesHistory: [
       {
         role: 'system',
-        content: `Rewrite the following to be significantly more strongly worded, graphic and explicit.
-          Imagine you are a cringy teenager writing a post on 4chan. Use explicit language as much as possible.`
+        content: 'Create 3 parapharses of the sentence: "{{?input}}"'
       }
     ],
     inputParams: {
-      input: 'Tabs are better than spaces, prove me wrong.'
+      input: 'I hate you!'
     }
   });
 

--- a/sample-code/src/orchestration.ts
+++ b/sample-code/src/orchestration.ts
@@ -123,7 +123,7 @@ export async function orchestrationOutputFiltering(): Promise<OrchestrationRespo
     messagesHistory: [
       {
         role: 'system',
-        content: 'Create 3 parapharses of the sentence: "{{?input}}"'
+        content: 'Create 3 paraphrases of the sentence: "{{?input}}"'
       }
     ],
     inputParams: {


### PR DESCRIPTION
## Context

Our output filter tests sometimes do not work as intended, as the LLM refuses to create content that would hit the filter.
With the new prompt, the LLM should reliably create the intended output, which will then hit the output filter.

Orchestration colleagues use the [same prompt](https://github.tools.sap/AI/llm-orchestration/blob/7fac544359cf60ce61093b46acbf67ee17a7cc40/tests_integration/test_orchestration_streaming.py#L412) to test their output filtering.