### PR TITLE
chore: Fix public api check

### DIFF
--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jsdoc/require-jsdoc */
 
-import path, { join, resolve, parse, basename, dirname, posix, sep } from 'path';
+import { join, resolve, parse, basename, dirname, posix, sep } from 'path';
 import { fileURLToPath } from 'url';
 import { promises, existsSync } from 'fs';
 import { glob } from 'glob';

--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jsdoc/require-jsdoc */
 
-import { join, resolve, parse, basename, dirname, posix, sep } from 'path';
+import path, { join, resolve, parse, basename, dirname, posix, sep } from 'path';
 import { fileURLToPath } from 'url';
 import { promises, existsSync } from 'fs';
 import { glob } from 'glob';
@@ -54,8 +54,8 @@ function paths(pathToPackage: string): {
   };
 }
 
-function getPathWithPosixSeparator(path: string): string {
-  return path.split(sep).join(posix.sep);
+function getPathWithPosixSeparator(filePath: string): string {
+  return filePath.split(sep).join(posix.sep);
 }
 
 /**

--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -26,11 +26,12 @@ export const regexExportedIndex = /\{([\w,]+)\}from'\./g;
 export const regexExportedInternal = /\.\/([\w-]+)/g;
 
 function mockFileSystem(pathToPackage: string) {
-  const { pathToSource, pathToTsConfig, pathToNodeModules } =
+  const { pathToSource, pathToTsConfig, pathToNodeModules, pathToPackageJson } =
     paths(pathToPackage);
   mock({
     [pathToTsConfig]: mock.load(pathToTsConfig),
     [pathToSource]: mock.load(pathToSource),
+    [pathToPackageJson]: mock.load(pathToPackageJson),
     [pathRootNodeModules]: mock.load(pathRootNodeModules),
     [pathToNodeModules]: mock.load(pathToNodeModules),
     [pathToTsConfigRoot]: mock.load(pathToTsConfigRoot)
@@ -39,16 +40,22 @@ function mockFileSystem(pathToPackage: string) {
 
 function paths(pathToPackage: string): {
   pathToSource: string;
+  pathToPackageJson: string;
   pathToTsConfig: string;
   pathToNodeModules: string;
   pathCompiled: string;
 } {
   return {
-    pathToSource: join(pathToPackage, 'src'),
-    pathToTsConfig: join(pathToPackage, 'tsconfig.json'),
-    pathToNodeModules: join(pathToPackage, 'node_modules'),
+    pathToSource: getPathWithPosixSeparator(join(pathToPackage, 'src')),
+    pathToPackageJson: getPathWithPosixSeparator(join(pathToPackage, 'package.json')),
+    pathToTsConfig: getPathWithPosixSeparator(join(pathToPackage, 'tsconfig.json')),
+    pathToNodeModules: getPathWithPosixSeparator(join(pathToPackage, 'node_modules')),
     pathCompiled: 'dist'
   };
+}
+
+function getPathWithPosixSeparator(path: string): string {
+  return path.split(sep).join(posix.sep);
 }
 
 /**
@@ -91,7 +98,7 @@ function compareApisAndLog(
     if (
       !allExportedIndex.find(nameInIndex => exportedType.name === nameInIndex)
     ) {
-      if (exportedType.path.split(sep).join(posix.sep).match(schemaPathRegex)) {
+      if (getPathWithPosixSeparator(exportedType.path).match(schemaPathRegex)) {
         logger.warn(
           `The ${exportedType.type} "${exportedType.name}" in file: ${exportedType.path} is not exported in the index.ts.`
         );


### PR DESCRIPTION
## Context

The public api check started failing for ai-api (now because we added `Node16` option in this [PR](https://github.com/SAP/cloud-sdk-js/pull/5184)), before it defaulted to `module: commonjs`, which means `moduleResolution: node`. This settings does not give compilation errors when esm is used with require syntax).

It fails because program.emit() still transpiles to commonjs but because `moduleResolution` is `node16`, it gives compile-time errors. `emit()` function was not able to infer that the sourceFile is esm because it didn't find a package.json file and therefore didnt find `type: module` setting. 

@shibeshduw This should be fixed in the github action as well (in the cloud sdk) 

## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated