### PR TITLE
fix: E2E due to large token consumption

### DIFF
--- a/sample-code/src/foundation-models/azure-openai.ts
+++ b/sample-code/src/foundation-models/azure-openai.ts
@@ -45,34 +45,9 @@ export async function chatCompletionStream(
       messages: [
         {
           role: 'user',
-          content: 'Give me a very long introduction of SAP Cloud SDK.'
+          content: 'Give me a short introduction of SAP Cloud SDK.'
         }
       ]
-    },
-    controller
-  );
-  return response;
-}
-
-/**
- * Ask Azure OpenAI model about the capital of France with streaming.
- * @param controller - The abort controller.
- * @returns The response from Azure OpenAI containing the response content.
- */
-export async function chatCompletionStreamMultipleChoices(
-  controller: AbortController
-): Promise<
-  AzureOpenAiChatCompletionStreamResponse<AzureOpenAiChatCompletionStreamChunkResponse>
-> {
-  const response = await new AzureOpenAiChatClient('gpt-35-turbo').stream(
-    {
-      messages: [
-        {
-          role: 'user',
-          content: 'Give me a very long introduction of SAP Cloud SDK.'
-        }
-      ],
-      n: 2
     },
     controller
   );


### PR DESCRIPTION
## Context

~AI/gen-ai-hub-sdk-js-backlog#ISSUENUMBER.~

E2E was failing due to a prompt, which causes a large amount of token consumption.

## Definition of Done

- ~[ ] Code is tested (Unit, E2E)~
- ~[ ] Error handling created / updated & covered by the tests above~
- ~[ ] Documentation updated~
- ~[ ] (Optional) Aligned changes with the Java SDK~
- ~[ ] (Optional) Release notes updated~