### PR TITLE
chore: Ignore nested folders in generated client in public API check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         uses: sap/cloud-sdk-js/.github/actions/check-public-api@main
         with:
           force_internal_exports: 'false'
-          ignored_path_pattern: '.*?\/client\/.*?\/schema'
+          ignored_path_pattern: '.*?/client/.*?/schema'
       - name: Check dependencies
         run: pnpm check:deps
       - name: License Check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         uses: sap/cloud-sdk-js/.github/actions/check-public-api@main
         with:
           force_internal_exports: 'false'
-          ignored_path_pattern: '.*?/client/[^/]+/schema'
+          ignored_path_pattern: '.*?\/client\/.*?\/schema'
       - name: Check dependencies
         run: pnpm check:deps
       - name: License Check


### PR DESCRIPTION
## Context

The public API check ignores checking the generated client as it currently ignores paths matching `.*?/client/[^/]+/schema`

For the RAGe client, we had to introduce a nested folder structure.
Hence, updating the regex for public API check, to also ignore nested folder structures in the generated client.

## Definition of Done

- [x] Regex was tested in regex evaluator
- ~[ ] Error handling created / updated & covered by the tests above~
- ~[ ] Documentation updated~
- ~[ ] (Optional) Aligned changes with the Java SDK~
- ~[ ] (Optional) Release notes updated~