### PR TITLE
fix: Remove help.sap.com in orchestration doc

### DIFF
--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -311,7 +311,7 @@ const orchestrationClient = new OrchestrationClient({
           id: 'filter1',
           data_repositories: ['*'],
           search_config: {},
-          data_repository_type: 'help.sap.com'
+          data_repository_type: 'vector'
         }
       ],
       input_params: ['groundingRequest'],


### PR DESCRIPTION
## Context

SAP/ai-sdk-js-backlog#180.

Tiny fix to remove `help.sap.com` in documentation.

## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated