### PR TITLE
fix: Smoke tests missing dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       '@sap-ai-sdk/ai-api':
         specifier: canary
         version: 1.4.1-20241215013214.0
+      '@sap-ai-sdk/document-grounding':
+        specifier: canary
+        version: 1.4.1-20241216013202.0
       '@sap-ai-sdk/foundation-models':
         specifier: canary
         version: 1.4.1-20241215013214.0
@@ -1032,6 +1035,12 @@ packages:
 
   '@sap-ai-sdk/core@1.4.1-20241215013214.0':
     resolution: {integrity: sha512-tazWEFQipPZ5YoynS+VSxWA2s7gLYy4ZsUiCDhHEU4kSpX7FDeUGdFHZzI2V+zpT1/PeSzoNAv4MTV0KnUTxCw==}
+
+  '@sap-ai-sdk/core@1.4.1-20241216013202.0':
+    resolution: {integrity: sha512-Xu6wFKWCjJX0Af42AA2U9FYJvq/qp2dppC3fopllJXhvt9Biwm8H/SHYF0HK7KxqtyGSYfvGssctvwuuz3OLUw==}
+
+  '@sap-ai-sdk/document-grounding@1.4.1-20241216013202.0':
+    resolution: {integrity: sha512-44zcnA/JrrVgL5cv5GA/fFLO4uzk8IwJhRZq73MyTyLjxibaoNpmBwTy9OxbzAaAYp2uje3yhc7Tzcmn4DpDcg==}
 
   '@sap-ai-sdk/foundation-models@1.4.1-20241215013214.0':
     resolution: {integrity: sha512-0fZHvQlJ7qh8ETKtF9KH2BMdls/T9m7J95GJQLMJYJtm7SplFnPKfolOpa5Mtlqwb0lGhAdUPOX1um44XK42GQ==}
@@ -5565,6 +5574,23 @@ snapshots:
       - debug
       - supports-color
 
+  '@sap-ai-sdk/core@1.4.1-20241216013202.0':
+    dependencies:
+      '@sap-cloud-sdk/connectivity': 3.24.0
+      '@sap-cloud-sdk/http-client': 3.24.0
+      '@sap-cloud-sdk/openapi': 3.24.0
+      '@sap-cloud-sdk/util': 3.24.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-ai-sdk/document-grounding@1.4.1-20241216013202.0':
+    dependencies:
+      '@sap-ai-sdk/core': 1.4.1-20241216013202.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@sap-ai-sdk/foundation-models@1.4.1-20241215013214.0':
     dependencies:
       '@sap-ai-sdk/ai-api': 1.4.1-20241215013214.0
@@ -5621,7 +5647,7 @@ snapshots:
       eslint: 9.17.0
       eslint-config-prettier: 9.1.0(eslint@9.17.0)
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0))(eslint@9.17.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.17.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0))(eslint@9.17.0))(eslint@9.17.0)
       eslint-plugin-jsdoc: 50.6.0(eslint@9.17.0)
       eslint-plugin-prettier: 5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@9.17.0))(eslint@9.17.0)(prettier@3.4.2)
       eslint-plugin-regex: 1.10.0(eslint@9.17.0)
@@ -7020,7 +7046,7 @@ snapshots:
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.17.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0))(eslint@9.17.0))(eslint@9.17.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -7038,7 +7064,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.17.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.16.0(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0))(eslint@9.17.0))(eslint@9.17.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8

--- a/tests/smoke-tests/package.json
+++ b/tests/smoke-tests/package.json
@@ -25,6 +25,7 @@
     "@sap-ai-sdk/foundation-models": "canary",
     "@sap-ai-sdk/langchain": "canary",
     "@sap-ai-sdk/orchestration": "canary",
+    "@sap-ai-sdk/document-grounding": "canary",
     "@sap-cloud-sdk/util": "^3.24.0",
     "express": "^4.21.2"
   },


### PR DESCRIPTION
## Context

~SAP/ai-sdk-js-backlog#ISSUENUMBER.~

Smoke tests package was missing `@sap-ai-sdk/document-grounding` dependency.

## Definition of Done

- [X] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated