### PR TITLE
fix: Deployment-api e2e-tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -43,8 +43,6 @@ jobs:
             fi
           done
           wget -qO- -S --content-on-error localhost:8080
-      - name: 'Cleanup Deployments'
-        run: pnpm e2e-tests cleanup-deployments
       - name: 'Execute E2E Tests'
         run: pnpm test:e2e
       - name: 'Slack Notification'

--- a/tests/e2e-tests/README.md
+++ b/tests/e2e-tests/README.md
@@ -22,4 +22,4 @@ End-to-end tests for the SAP Cloud SDK for AI.
 
 ## Remote Testing
 
-Trigger the [GitHub Action](https://github.com/SAP/ai-sdk-js/actions/workflows/e2e-test.yml).
+Trigger the [GitHub Action](https://github.com/SAP/ai-sdk-js/actions/workflows/e2e-tests.yaml).

--- a/tests/e2e-tests/src/deployment-api.test.ts
+++ b/tests/e2e-tests/src/deployment-api.test.ts
@@ -59,8 +59,10 @@ describe('DeploymentApi', () => {
     await new Promise(r => setTimeout(r, 60000));
     const finalDeployments = await getDeployments(resourceGroup);
 
-    if(finalDeployments.count) {
-      expect(finalDeployments.resources.map(deployment => deployment.id)).not.toContain(createdDeploymentId);
+    if (finalDeployments.count) {
+      expect(
+        finalDeployments.resources.map(deployment => deployment.id)
+      ).not.toContain(createdDeploymentId);
     }
   }, 75000);
 });


### PR DESCRIPTION
## Context

SAP/ai-sdk-js-backlog#211.

## What this PR does and why it is needed

This PR aligns the e2e tests with the [Java sdk](https://github.com/SAP/ai-sdk-java/blob/fcab936bb6b9c068d27d0ddf6d15feb3dad2cf2a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/DeploymentTest.java#L14). Essentially we ignore the modify endpoint and just delete a newly created deployment. 

Test run: https://github.com/SAP/ai-sdk-js/actions/runs/12691689015

I have also removed cleanup deployments from GH Actions but left the script as it is because it is still useful as a utility imo.
