### PR TITLE
chore: Include gpt-4o-mini for orchestration

### DIFF
--- a/packages/orchestration/src/model-types.ts
+++ b/packages/orchestration/src/model-types.ts
@@ -9,7 +9,7 @@ import type {
  * Supported chat models for orchestration.
  */
 export type ChatModel =
-  | Exclude<AzureOpenAiChatModel, 'gpt-4o-mini'>
+  | AzureOpenAiChatModel
   | GcpVertexAiChatModel
   | AwsBedrockChatModel
   | AiCoreOpenSourceChatModel;


### PR DESCRIPTION
## Context

SAP/ai-sdk-js-backlog#202.

## What this PR does and why it is needed

Remove exclusion of gpt-4o-mini for orchestration.