### PR TITLE
chore: Add documentation to replace API version in Azure OpenAI Client

### DIFF
--- a/packages/foundation-models/README.md
+++ b/packages/foundation-models/README.md
@@ -277,7 +277,7 @@ To disable caching, set the `useCache` parameter to `false` together with the `d
 
 ### Overwriting API Version
 
-We are continously updating the OpenAI API version to match the latest version.
+We are continuously updating the OpenAI API version to match the latest version.
 In case this behavior causes issues in your application, you can overwrite the API version.
 
 To do this, set the `api-version` parameter in the `CustomRequestConfig` object, like the following:

--- a/packages/foundation-models/README.md
+++ b/packages/foundation-models/README.md
@@ -275,6 +275,21 @@ const client = await new AzureOpenAiChatClient('gpt-35-turbo', {
 By default, the fetched destination is cached.
 To disable caching, set the `useCache` parameter to `false` together with the `destinationName` parameter.
 
+### Overwriting API Version
+
+We are continously updating the OpenAI API version to match the latest version.
+In case this behavior causes issues in your application, you can overwrite the API version.
+
+To do this, set the `api-version` parameter in a `CustomRequestConfig` object, like the following:
+
+```ts
+const client = await new AzureOpenAiChatClient('gpt-35-turbo', {
+  destinationName: 'my-destination',
+});
+
+client.run({ messages: [{ role: 'user', content: 'YOUR_PROMPT' }] }, { params: { 'api-version': 'YOUR_OLD_VERSION' } });
+```
+
 ## Local Testing
 
 For local testing instructions, refer to this [section](https://github.com/SAP/ai-sdk-js/blob/main/README.md#local-testing).

--- a/packages/foundation-models/README.md
+++ b/packages/foundation-models/README.md
@@ -280,7 +280,7 @@ To disable caching, set the `useCache` parameter to `false` together with the `d
 We are continously updating the OpenAI API version to match the latest version.
 In case this behavior causes issues in your application, you can overwrite the API version.
 
-To do this, set the `api-version` parameter in a `CustomRequestConfig` object, like the following:
+To do this, set the `api-version` parameter in the `CustomRequestConfig` object, like the following:
 
 ```ts
 const client = await new AzureOpenAiChatClient('gpt-35-turbo', {

--- a/packages/foundation-models/README.md
+++ b/packages/foundation-models/README.md
@@ -284,10 +284,13 @@ To do this, set the `api-version` parameter in a `CustomRequestConfig` object, l
 
 ```ts
 const client = await new AzureOpenAiChatClient('gpt-35-turbo', {
-  destinationName: 'my-destination',
+  destinationName: 'my-destination'
 });
 
-client.run({ messages: [{ role: 'user', content: 'YOUR_PROMPT' }] }, { params: { 'api-version': 'YOUR_OLD_VERSION' } });
+client.run(
+  { messages: [{ role: 'user', content: 'YOUR_PROMPT' }] },
+  { params: { 'api-version': 'YOUR_OLD_VERSION' } }
+);
 ```
 
 ## Local Testing


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#166.

## What this PR does and why it is needed

 Adds documentation to replace API version in Azure OpenAI Client
