### PR TITLE
feat: Add descriptive constants for Azure content filter configuration - Option 1

### DIFF
--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -369,7 +369,10 @@ import {
   buildAzureContentFilter
 } from '@sap-ai-sdk/orchestration';
 
-const filter = buildAzureContentFilter({ Hate: 2, Violence: 4 });
+const filter = buildAzureContentFilter({
+  Hate: AzureFilterThreshold.ALLOW_SAFE_LOW,
+  Violence: AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM
+});
 const orchestrationClient = new OrchestrationClient({
   llm: {
     model_name: 'gpt-4o',
@@ -409,7 +412,7 @@ Therefore, handle errors appropriately to ensure meaningful feedback for both ty
 
 `buildAzureContentFilter()` is a convenience function that creates an Azure content filter configuration based on the provided inputs.
 The Azure content filter supports four categories: `Hate`, `Violence`, `Sexual`, and `SelfHarm`.
-Each category can be configured with severity levels of 0, 2, 4, or 6.
+Each category can be configured with severity levels of `ALLOW_SAFE`, `ALLOW_SAFE_LOW`, `ALLOW_SAFE_LOW_MEDIUM` and `ALLOW_ALL` which correspond to Azure threshold values of 0, 2, 4, or 6 respectively.
 
 ### Data Masking
 

--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -11,7 +11,7 @@ export type {
   LlmModelParams
 } from './orchestration-types.js';
 
-export { AzureContentSafetyThreshold } from './orchestration-types.js';
+export { AzureFilterThreshold } from './orchestration-types.js';
 export { OrchestrationStreamResponse } from './orchestration-stream-response.js';
 
 export { OrchestrationStreamChunkResponse } from './orchestration-stream-chunk-response.js';

--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -11,6 +11,7 @@ export type {
   LlmModelParams
 } from './orchestration-types.js';
 
+export { AzureContentSafetyThreshold } from './orchestration-types.js';
 export { OrchestrationStreamResponse } from './orchestration-stream-response.js';
 
 export { OrchestrationStreamChunkResponse } from './orchestration-stream-chunk-response.js';

--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -8,10 +8,16 @@ export type {
   StreamOptions,
   DocumentGroundingServiceConfig,
   DocumentGroundingServiceFilter,
-  LlmModelParams
+  LlmModelParams,
+  AzureContentSafety,
+  AzureFilterThresholdType,
+  AzureThresholdType
 } from './orchestration-types.js';
 
-export { AzureFilterThreshold } from './orchestration-types.js';
+export {
+  AzureFilterThreshold,
+  isAzureFilterThresholdType
+} from './orchestration-types.js';
 export { OrchestrationStreamResponse } from './orchestration-stream-response.js';
 
 export { OrchestrationStreamChunkResponse } from './orchestration-stream-chunk-response.js';

--- a/packages/orchestration/src/orchestration-client.test.ts
+++ b/packages/orchestration/src/orchestration-client.test.ts
@@ -164,10 +164,13 @@ describe('orchestration service client', () => {
       },
       filtering: {
         input: buildAzureContentFilter({
-          Hate: 4,
-          SelfHarm: 2
+          Hate: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM,
+          SelfHarm: AzureContentSafetyThreshold.ALLOW_SAFE_LOW
         }),
-        output: buildAzureContentFilter({ Sexual: 0, Violence: 4 })
+        output: buildAzureContentFilter({
+          Sexual: AzureContentSafetyThreshold.ALLOW_SAFE,
+          Violence: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM
+        })
       }
     };
     const prompt = {

--- a/packages/orchestration/src/orchestration-client.test.ts
+++ b/packages/orchestration/src/orchestration-client.test.ts
@@ -15,7 +15,7 @@ import {
   constructCompletionPostRequestFromJsonModuleConfig
 } from './orchestration-utils.js';
 import { OrchestrationResponse } from './orchestration-response.js';
-import { AzureContentSafetyThreshold } from './orchestration-types.js';
+import { AzureFilterThreshold } from './orchestration-types.js';
 import type { CompletionPostResponse } from './client/api/schema/index.js';
 import type {
   OrchestrationModuleConfig,
@@ -164,12 +164,12 @@ describe('orchestration service client', () => {
       },
       filtering: {
         input: buildAzureContentFilter({
-          Hate: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM,
-          SelfHarm: AzureContentSafetyThreshold.ALLOW_SAFE_LOW
+          Hate: AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM,
+          SelfHarm: AzureFilterThreshold.ALLOW_SAFE_LOW
         }),
         output: buildAzureContentFilter({
-          Sexual: AzureContentSafetyThreshold.ALLOW_SAFE,
-          Violence: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM
+          Sexual: AzureFilterThreshold.ALLOW_SAFE,
+          Violence: AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM
         })
       }
     };
@@ -219,8 +219,8 @@ describe('orchestration service client', () => {
             {
               type: 'azure_content_safety' as const,
               config: {
-                Hate: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM,
-                SelfHarm: AzureContentSafetyThreshold.ALLOW_SAFE_LOW
+                Hate: AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM,
+                SelfHarm: AzureFilterThreshold.ALLOW_SAFE_LOW
               }
             }
           ]
@@ -230,8 +230,8 @@ describe('orchestration service client', () => {
             {
               type: 'azure_content_safety' as const,
               config: {
-                Sexual: AzureContentSafetyThreshold.ALLOW_SAFE,
-                Violence: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM
+                Sexual: AzureFilterThreshold.ALLOW_SAFE,
+                Violence: AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM
               }
             }
           ]

--- a/packages/orchestration/src/orchestration-client.test.ts
+++ b/packages/orchestration/src/orchestration-client.test.ts
@@ -164,12 +164,12 @@ describe('orchestration service client', () => {
       },
       filtering: {
         input: buildAzureContentFilter({
-          Hate: AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM,
-          SelfHarm: AzureFilterThreshold.ALLOW_SAFE_LOW
+          Hate: 'ALLOW_ALL',
+          SelfHarm: 'ALLOW_SAFE_LOW'
         }),
         output: buildAzureContentFilter({
-          Sexual: AzureFilterThreshold.ALLOW_SAFE,
-          Violence: AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM
+          Sexual: 'ALLOW_SAFE',
+          Violence: 'ALLOW_SAFE_LOW_MEDIUM'
         })
       }
     };

--- a/packages/orchestration/src/orchestration-client.test.ts
+++ b/packages/orchestration/src/orchestration-client.test.ts
@@ -15,6 +15,7 @@ import {
   constructCompletionPostRequestFromJsonModuleConfig
 } from './orchestration-utils.js';
 import { OrchestrationResponse } from './orchestration-response.js';
+import { AzureContentSafetyThreshold } from './orchestration-types.js';
 import type { CompletionPostResponse } from './client/api/schema/index.js';
 import type {
   OrchestrationModuleConfig,
@@ -162,7 +163,10 @@ describe('orchestration service client', () => {
         ]
       },
       filtering: {
-        input: buildAzureContentFilter({ Hate: 4, SelfHarm: 2 }),
+        input: buildAzureContentFilter({
+          Hate: 4,
+          SelfHarm: 2
+        }),
         output: buildAzureContentFilter({ Sexual: 0, Violence: 4 })
       }
     };
@@ -212,8 +216,8 @@ describe('orchestration service client', () => {
             {
               type: 'azure_content_safety' as const,
               config: {
-                Hate: 4 as const,
-                SelfHarm: 2 as const
+                Hate: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM,
+                SelfHarm: AzureContentSafetyThreshold.ALLOW_SAFE_LOW
               }
             }
           ]
@@ -223,8 +227,8 @@ describe('orchestration service client', () => {
             {
               type: 'azure_content_safety' as const,
               config: {
-                Sexual: 0 as const,
-                Violence: 4 as const
+                Sexual: AzureContentSafetyThreshold.ALLOW_SAFE,
+                Violence: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM
               }
             }
           ]

--- a/packages/orchestration/src/orchestration-client.test.ts
+++ b/packages/orchestration/src/orchestration-client.test.ts
@@ -168,8 +168,8 @@ describe('orchestration service client', () => {
           SelfHarm: 'ALLOW_SAFE_LOW'
         }),
         output: buildAzureContentFilter({
-          Sexual: 'ALLOW_SAFE',
-          Violence: 'ALLOW_SAFE_LOW_MEDIUM'
+          Sexual: 0,
+          Violence: 4
         })
       }
     };

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -10,7 +10,8 @@ import type {
   GroundingModuleConfig,
   MaskingModuleConfig,
   LlmModuleConfig as OriginalLlmModuleConfig,
-  TemplatingModuleConfig
+  TemplatingModuleConfig,
+  AzureThreshold
 } from './client/api/schema/index.js';
 
 /**
@@ -154,26 +155,26 @@ export interface DocumentGroundingServiceConfig {
 
 /**
  * A descriptive  type for AzureThreshold input.
- * @internal
  */
-export interface AzureContentSafety {
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type AzureContentSafety = {
   /**
    * The filter category for hate content.
    */
-  Hate?: AzureFilterThresholdType;
+  Hate?: AzureThresholdType;
   /**
    * The filter category for self-harm content.
    */
-  SelfHarm?: AzureFilterThresholdType;
+  SelfHarm?: AzureThresholdType;
   /**
    * The filter category for sexual content.
    */
-  Sexual?: AzureFilterThresholdType;
+  Sexual?: AzureThresholdType;
   /**
    * The filter category for violence content.
    */
-  Violence?: AzureFilterThresholdType;
-}
+  Violence?: AzureThresholdType;
+};
 
 /**
  * A descriptive constant for Azure content safety threshold.
@@ -186,12 +187,22 @@ export const AzureFilterThreshold = {
 } as const;
 
 /**
+ * Type for azure filter threshold constant.
+ */
+export type AzureFilterThresholdType = keyof typeof AzureFilterThreshold;
+/**
  * Type for azure filter threshold autocompletion.
  * A union of numeric values too for now, to avoid breaking changes.
  */
-type AzureFilterThresholdType =
-  | keyof typeof AzureFilterThreshold
-  | 0
-  | 2
-  | 4
-  | 6;
+export type AzureThresholdType = AzureFilterThresholdType | AzureThreshold;
+
+/**
+ * Type guard to check if a value is a valid AzureFilterThresholdType.
+ * @param value - Value to check for type.
+ * @returns A Boolean value.
+ **/
+export function isAzureFilterThresholdType(
+  value: any
+): value is AzureFilterThresholdType {
+  return value in AzureFilterThreshold;
+}

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -1,6 +1,7 @@
 import type { CustomRequestConfig } from '@sap-cloud-sdk/http-client';
 import type { ChatModel } from './model-types.js';
 import type {
+  AzureThreshold,
   ChatMessages,
   DataRepositoryType,
   DocumentGroundingFilter,
@@ -151,3 +152,13 @@ export interface DocumentGroundingServiceConfig {
    */
   output_param: string;
 }
+
+/**
+ * A descriptive constant for AzureThreshold.
+ */
+export const AzureContentSafetyThreshold: { [K in string]: AzureThreshold } = {
+  ALLOW_SAFE: 0,
+  ALLOW_SAFE_LOW: 2,
+  ALLOW_SAFE_LOW_MEDIUM: 4,
+  ALLOW_ALL: 6
+} as const;

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -1,7 +1,6 @@
 import type { CustomRequestConfig } from '@sap-cloud-sdk/http-client';
 import type { ChatModel } from './model-types.js';
 import type {
-  AzureThreshold,
   ChatMessages,
   DataRepositoryType,
   DocumentGroundingFilter,
@@ -157,23 +156,42 @@ export interface DocumentGroundingServiceConfig {
  * A descriptive  type for AzureThreshold input.
  * @internal
  */
-export interface AzureContentSafetyThresholdType {
-  /** Only safe content is allowed. AzureThreshold value of 0. */
-  readonly ALLOW_SAFE: AzureThreshold;
-  /** Safe and low-risk content is allowed. AzureThreshold value of 2.*/
-  readonly ALLOW_SAFE_LOW: AzureThreshold;
-  /** Safe, low-risk, and medium-risk content is allowed. AzureThreshold value of 4. */
-  readonly ALLOW_SAFE_LOW_MEDIUM: AzureThreshold;
-  /** All content is allowed. AzureThreshold value of 6. */
-  readonly ALLOW_ALL: AzureThreshold;
+export interface AzureContentSafety {
+  /**
+   * The filter category for hate content.
+   */
+  Hate?: AzureFilterThresholdType;
+  /**
+   * The filter category for self-harm content.
+   */
+  SelfHarm?: AzureFilterThresholdType;
+  /**
+   * The filter category for sexual content.
+   */
+  Sexual?: AzureFilterThresholdType;
+  /**
+   * The filter category for violence content.
+   */
+  Violence?: AzureFilterThresholdType;
 }
 
 /**
- * A descriptive constant for AzureThreshold.
+ * A descriptive constant for Azure content safety threshold.
  */
-export const AzureFilterThreshold: AzureContentSafetyThresholdType = {
+export const AzureFilterThreshold = {
   ALLOW_SAFE: 0,
   ALLOW_SAFE_LOW: 2,
   ALLOW_SAFE_LOW_MEDIUM: 4,
   ALLOW_ALL: 6
 } as const;
+
+/**
+ * Type for azure filter threshold autocompletion.
+ * A union of numeric values too for now, to avoid breaking changes.
+ */
+type AzureFilterThresholdType =
+  | keyof typeof AzureFilterThreshold
+  | 0
+  | 2
+  | 4
+  | 6;

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -171,7 +171,7 @@ export interface AzureContentSafetyThresholdType {
 /**
  * A descriptive constant for AzureThreshold.
  */
-export const AzureContentSafetyThreshold: AzureContentSafetyThresholdType = {
+export const AzureFilterThreshold: AzureContentSafetyThresholdType = {
   ALLOW_SAFE: 0,
   ALLOW_SAFE_LOW: 2,
   ALLOW_SAFE_LOW_MEDIUM: 4,

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -154,9 +154,24 @@ export interface DocumentGroundingServiceConfig {
 }
 
 /**
+ * A descriptive  type for AzureThreshold input.
+ * @internal
+ */
+export interface AzureContentSafetyThresholdType {
+  /** Only safe content is allowed. AzureThreshold value of 0. */
+  readonly ALLOW_SAFE: AzureThreshold;
+  /** Safe and low-risk content is allowed. AzureThreshold value of 2.*/
+  readonly ALLOW_SAFE_LOW: AzureThreshold;
+  /** Safe, low-risk, and medium-risk content is allowed. AzureThreshold value of 4. */
+  readonly ALLOW_SAFE_LOW_MEDIUM: AzureThreshold;
+  /** All content is allowed. AzureThreshold value of 6. */
+  readonly ALLOW_ALL: AzureThreshold;
+}
+
+/**
  * A descriptive constant for AzureThreshold.
  */
-export const AzureContentSafetyThreshold: { [K in string]: AzureThreshold } = {
+export const AzureContentSafetyThreshold: AzureContentSafetyThresholdType = {
   ALLOW_SAFE: 0,
   ALLOW_SAFE_LOW: 2,
   ALLOW_SAFE_LOW_MEDIUM: 4,

--- a/packages/orchestration/src/orchestration-utils.test.ts
+++ b/packages/orchestration/src/orchestration-utils.test.ts
@@ -12,7 +12,7 @@ import {
   type OrchestrationModuleConfig,
   type DocumentGroundingServiceConfig,
   type StreamOptions,
-  AzureContentSafetyThreshold
+  AzureFilterThreshold
 } from './orchestration-types.js';
 import type {
   CompletionPostRequest,
@@ -176,8 +176,8 @@ describe('orchestration utils', () => {
     it('constructs filter configuration with only input', async () => {
       const filtering: FilteringModuleConfig = {
         input: buildAzureContentFilter({
-          Hate: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM,
-          SelfHarm: AzureContentSafetyThreshold.ALLOW_SAFE
+          Hate: AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM,
+          SelfHarm: AzureFilterThreshold.ALLOW_SAFE
         })
       };
       const expectedFilterConfig: FilteringModuleConfig = {
@@ -205,8 +205,8 @@ describe('orchestration utils', () => {
     it('constructs filter configuration with only output', async () => {
       const filtering: FilteringModuleConfig = {
         output: buildAzureContentFilter({
-          Sexual: AzureContentSafetyThreshold.ALLOW_SAFE_LOW,
-          Violence: AzureContentSafetyThreshold.ALLOW_ALL
+          Sexual: AzureFilterThreshold.ALLOW_SAFE_LOW,
+          Violence: AzureFilterThreshold.ALLOW_ALL
         })
       };
       const expectedFilterConfig: FilteringModuleConfig = {
@@ -234,10 +234,10 @@ describe('orchestration utils', () => {
     it('constructs filter configuration with both input and output', async () => {
       const filtering: FilteringModuleConfig = {
         input: buildAzureContentFilter({
-          Hate: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM,
-          SelfHarm: AzureContentSafetyThreshold.ALLOW_SAFE,
-          Sexual: AzureContentSafetyThreshold.ALLOW_SAFE_LOW,
-          Violence: AzureContentSafetyThreshold.ALLOW_ALL
+          Hate: AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM,
+          SelfHarm: AzureFilterThreshold.ALLOW_SAFE,
+          Sexual: AzureFilterThreshold.ALLOW_SAFE_LOW,
+          Violence: AzureFilterThreshold.ALLOW_ALL
         }),
         output: buildAzureContentFilter({ Sexual: 2, Violence: 6 })
       };

--- a/packages/orchestration/src/orchestration-utils.test.ts
+++ b/packages/orchestration/src/orchestration-utils.test.ts
@@ -8,17 +8,18 @@ import {
   buildDocumentGroundingConfig,
   constructCompletionPostRequest
 } from './orchestration-utils.js';
+import {
+  type OrchestrationModuleConfig,
+  type DocumentGroundingServiceConfig,
+  type StreamOptions,
+  AzureContentSafetyThreshold
+} from './orchestration-types.js';
 import type {
   CompletionPostRequest,
   FilteringModuleConfig,
   ModuleConfigs,
   OrchestrationConfig
 } from './client/api/schema/index.js';
-import type {
-  OrchestrationModuleConfig,
-  DocumentGroundingServiceConfig,
-  StreamOptions
-} from './orchestration-types.js';
 
 describe('orchestration utils', () => {
   describe('stream util tests', () => {
@@ -174,7 +175,10 @@ describe('orchestration utils', () => {
 
     it('constructs filter configuration with only input', async () => {
       const filtering: FilteringModuleConfig = {
-        input: buildAzureContentFilter({ Hate: 4, SelfHarm: 0 })
+        input: buildAzureContentFilter({
+          Hate: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM,
+          SelfHarm: AzureContentSafetyThreshold.ALLOW_SAFE
+        })
       };
       const expectedFilterConfig: FilteringModuleConfig = {
         input: {
@@ -200,7 +204,10 @@ describe('orchestration utils', () => {
 
     it('constructs filter configuration with only output', async () => {
       const filtering: FilteringModuleConfig = {
-        output: buildAzureContentFilter({ Sexual: 2, Violence: 6 })
+        output: buildAzureContentFilter({
+          Sexual: AzureContentSafetyThreshold.ALLOW_SAFE_LOW,
+          Violence: AzureContentSafetyThreshold.ALLOW_ALL
+        })
       };
       const expectedFilterConfig: FilteringModuleConfig = {
         output: {
@@ -227,10 +234,10 @@ describe('orchestration utils', () => {
     it('constructs filter configuration with both input and output', async () => {
       const filtering: FilteringModuleConfig = {
         input: buildAzureContentFilter({
-          Hate: 4,
-          SelfHarm: 0,
-          Sexual: 2,
-          Violence: 6
+          Hate: AzureContentSafetyThreshold.ALLOW_SAFE_LOW_MEDIUM,
+          SelfHarm: AzureContentSafetyThreshold.ALLOW_SAFE,
+          Sexual: AzureContentSafetyThreshold.ALLOW_SAFE_LOW,
+          Violence: AzureContentSafetyThreshold.ALLOW_ALL
         }),
         output: buildAzureContentFilter({ Sexual: 2, Violence: 6 })
       };

--- a/packages/orchestration/src/orchestration-utils.ts
+++ b/packages/orchestration/src/orchestration-utils.ts
@@ -202,26 +202,14 @@ export function buildAzureContentFilter(
         type: 'azure_content_safety',
         ...(filter && {
           config: {
-            ...(filter.Hate !== undefined && {
-              Hate: isAzureFilterThresholdType(filter.Hate)
-                ? AzureFilterThreshold[filter.Hate]
-                : filter.Hate
-            }),
-            ...(filter.SelfHarm !== undefined && {
-              SelfHarm: isAzureFilterThresholdType(filter.SelfHarm)
-                ? AzureFilterThreshold[filter.SelfHarm]
-                : filter.SelfHarm
-            }),
-            ...(filter.Sexual !== undefined && {
-              Sexual: isAzureFilterThresholdType(filter.Sexual)
-                ? AzureFilterThreshold[filter.Sexual]
-                : filter.Sexual
-            }),
-            ...(filter.Violence !== undefined && {
-              Violence: isAzureFilterThresholdType(filter.Violence)
-                ? AzureFilterThreshold[filter.Violence]
-                : filter.Violence
-            })
+            ...Object.fromEntries(
+              Object.entries(filter).map(([key, value]) => [
+                key,
+                isAzureFilterThresholdType(value)
+                  ? AzureFilterThreshold[value]
+                  : value
+              ])
+            )
           }
         })
       }

--- a/packages/orchestration/src/orchestration-utils.ts
+++ b/packages/orchestration/src/orchestration-utils.ts
@@ -1,13 +1,15 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import type {
-  DocumentGroundingServiceConfig,
-  Prompt,
-  StreamOptions,
-  LlmModuleConfig,
-  OrchestrationModuleConfig
+import {
+  type DocumentGroundingServiceConfig,
+  type Prompt,
+  type StreamOptions,
+  type LlmModuleConfig,
+  type OrchestrationModuleConfig,
+  type AzureContentSafety,
+  AzureFilterThreshold,
+  isAzureFilterThresholdType
 } from './orchestration-types.js';
 import type {
-  AzureContentSafety,
   GroundingModuleConfig,
   InputFilteringConfig,
   CompletionPostRequest,
@@ -198,7 +200,30 @@ export function buildAzureContentFilter(
     filters: [
       {
         type: 'azure_content_safety',
-        ...(filter && { config: filter })
+        ...(filter && {
+          config: {
+            ...(filter.Hate !== undefined && {
+              Hate: isAzureFilterThresholdType(filter.Hate)
+                ? AzureFilterThreshold[filter.Hate]
+                : filter.Hate
+            }),
+            ...(filter.SelfHarm !== undefined && {
+              SelfHarm: isAzureFilterThresholdType(filter.SelfHarm)
+                ? AzureFilterThreshold[filter.SelfHarm]
+                : filter.SelfHarm
+            }),
+            ...(filter.Sexual !== undefined && {
+              Sexual: isAzureFilterThresholdType(filter.Sexual)
+                ? AzureFilterThreshold[filter.Sexual]
+                : filter.Sexual
+            }),
+            ...(filter.Violence !== undefined && {
+              Violence: isAzureFilterThresholdType(filter.Violence)
+                ? AzureFilterThreshold[filter.Violence]
+                : filter.Violence
+            })
+          }
+        })
       }
     ]
   };


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#181.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

This PR adds self descriptive constansts for improving Azure content filter configuration. 

<img width="620" alt="Screenshot 2025-01-23 at 12 28 28" src="https://github.com/user-attachments/assets/d6f24faa-4a55-4818-b812-401057d4164e" />




Autocompletion works with the string key values of `AzureFilterThreshold`  and the numeric allowed values 0,2,4 and 6 coming up in hints.
