### PR TITLE
chore: Regenerate AI Core client with a default base path

### DIFF
--- a/packages/ai-api/src/client/AI_CORE_API/application-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/application-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -20,6 +20,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ApplicationApi = {
+  _defaultBasePath: undefined,
   /**
    * Return all Argo CD application data objects.
    *
@@ -37,7 +38,8 @@ export const ApplicationApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ApplicationApi._defaultBasePath
     ),
   /**
    * Create an ArgoCD application to synchronise a repository.
@@ -56,7 +58,8 @@ export const ApplicationApi = {
       {
         body,
         headerParameters
-      }
+      },
+      ApplicationApi._defaultBasePath
     ),
   /**
    * Returns the ArgoCD application health and sync status.
@@ -75,7 +78,8 @@ export const ApplicationApi = {
       {
         pathParameters: { applicationName },
         headerParameters
-      }
+      },
+      ApplicationApi._defaultBasePath
     ),
   /**
    * Retrieve the ArgoCD application details.
@@ -94,7 +98,8 @@ export const ApplicationApi = {
       {
         pathParameters: { applicationName },
         headerParameters
-      }
+      },
+      ApplicationApi._defaultBasePath
     ),
   /**
    * Update the referenced ArgoCD application to synchronize the repository.
@@ -116,7 +121,8 @@ export const ApplicationApi = {
         pathParameters: { applicationName },
         body,
         headerParameters
-      }
+      },
+      ApplicationApi._defaultBasePath
     ),
   /**
    * Delete an ArgoCD application
@@ -134,7 +140,8 @@ export const ApplicationApi = {
       {
         pathParameters: { applicationName },
         headerParameters
-      }
+      },
+      ApplicationApi._defaultBasePath
     ),
   /**
    * Schedules a refresh of the specified application that will be picked up by ArgoCD asynchronously
@@ -153,6 +160,7 @@ export const ApplicationApi = {
       {
         pathParameters: { applicationName },
         headerParameters
-      }
+      },
+      ApplicationApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/artifact-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/artifact-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -16,6 +16,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ArtifactApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of artifacts that matches the specified filter criteria.
    * Filter criteria include scenario ID, execution ID, an artifact name, artifact kind, or artifact labels.
@@ -41,10 +42,15 @@ export const ArtifactApi = {
     },
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<AiArtifactList>('get', '/lm/artifacts', {
-      queryParameters,
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<AiArtifactList>(
+      'get',
+      '/lm/artifacts',
+      {
+        queryParameters,
+        headerParameters
+      },
+      ArtifactApi._defaultBasePath
+    ),
   /**
    * Register an artifact for use in a configuration, for example a model or a dataset.
    * @param body - Request body.
@@ -61,7 +67,8 @@ export const ArtifactApi = {
       {
         body,
         headerParameters
-      }
+      },
+      ArtifactApi._defaultBasePath
     ),
   /**
    * Retrieve details for artifact with artifactId.
@@ -75,11 +82,16 @@ export const ArtifactApi = {
     queryParameters: { $expand?: 'scenario' },
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<AiArtifact>('get', '/lm/artifacts/{artifactId}', {
-      pathParameters: { artifactId },
-      queryParameters,
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<AiArtifact>(
+      'get',
+      '/lm/artifacts/{artifactId}',
+      {
+        pathParameters: { artifactId },
+        queryParameters,
+        headerParameters
+      },
+      ArtifactApi._defaultBasePath
+    ),
   /**
    * Retrieve  the number of available artifacts that match the specified filter criteria.
    * Filter criteria include a scenarioId, executionId, an artifact name, artifact kind, or artifact labels.
@@ -101,8 +113,13 @@ export const ArtifactApi = {
     },
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<number>('get', '/lm/artifacts/$count', {
-      queryParameters,
-      headerParameters
-    })
+    new OpenApiRequestBuilder<number>(
+      'get',
+      '/lm/artifacts/$count',
+      {
+        queryParameters,
+        headerParameters
+      },
+      ArtifactApi._defaultBasePath
+    )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/configuration-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/configuration-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -15,6 +15,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ConfigurationApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of configurations. Filter results by scenario ID or a list of executable IDs.
    * Search for configurations containing the search string as substring in the configuration name.
@@ -41,7 +42,8 @@ export const ConfigurationApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ConfigurationApi._defaultBasePath
     ),
   /**
    * Create a new configuration linked to a specific scenario and executable for use in an execution
@@ -61,7 +63,8 @@ export const ConfigurationApi = {
       {
         body,
         headerParameters
-      }
+      },
+      ConfigurationApi._defaultBasePath
     ),
   /**
    * Retrieve details for configuration with configurationId.
@@ -82,7 +85,8 @@ export const ConfigurationApi = {
         pathParameters: { configurationId },
         queryParameters,
         headerParameters
-      }
+      },
+      ConfigurationApi._defaultBasePath
     ),
   /**
    * Retrieve the number of available configurations that match the specified filter criteria.
@@ -101,8 +105,13 @@ export const ConfigurationApi = {
     },
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<number>('get', '/lm/configurations/$count', {
-      queryParameters,
-      headerParameters
-    })
+    new OpenApiRequestBuilder<number>(
+      'get',
+      '/lm/configurations/$count',
+      {
+        queryParameters,
+        headerParameters
+      },
+      ConfigurationApi._defaultBasePath
+    )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/deployment-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/deployment-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -21,6 +21,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const DeploymentApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of deployments that match the specified filter criteria.
    * Filter criteria include a list of executableIds, a scenarioId, a configurationId, or a deployment status.
@@ -50,10 +51,15 @@ export const DeploymentApi = {
     },
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<AiDeploymentList>('get', '/lm/deployments', {
-      queryParameters,
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<AiDeploymentList>(
+      'get',
+      '/lm/deployments',
+      {
+        queryParameters,
+        headerParameters
+      },
+      DeploymentApi._defaultBasePath
+    ),
   /**
    * Create a deployment using the configuration specified by configurationId after synchronously checking the
    * correctness of the configuration.
@@ -72,7 +78,8 @@ export const DeploymentApi = {
       {
         body,
         headerParameters
-      }
+      },
+      DeploymentApi._defaultBasePath
     ),
   /**
    * Update status of multiple deployments. stop or delete multiple deployments.
@@ -90,7 +97,8 @@ export const DeploymentApi = {
       {
         body,
         headerParameters
-      }
+      },
+      DeploymentApi._defaultBasePath
     ),
   /**
    * Retrieve details for execution with deploymentId.
@@ -111,7 +119,8 @@ export const DeploymentApi = {
         pathParameters: { deploymentId },
         queryParameters,
         headerParameters
-      }
+      },
+      DeploymentApi._defaultBasePath
     ),
   /**
    * Update target status of a deployment to stop a deployment or change the configuration to be used by the
@@ -135,7 +144,8 @@ export const DeploymentApi = {
         pathParameters: { deploymentId },
         body,
         headerParameters
-      }
+      },
+      DeploymentApi._defaultBasePath
     ),
   /**
    * Mark deployment with deploymentId as deleted.
@@ -153,7 +163,8 @@ export const DeploymentApi = {
       {
         pathParameters: { deploymentId },
         headerParameters
-      }
+      },
+      DeploymentApi._defaultBasePath
     ),
   /**
    * Retrieve the number of available deployments. The number can be filtered by
@@ -179,10 +190,15 @@ export const DeploymentApi = {
     },
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<number>('get', '/lm/deployments/$count', {
-      queryParameters,
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<number>(
+      'get',
+      '/lm/deployments/$count',
+      {
+        queryParameters,
+        headerParameters
+      },
+      DeploymentApi._defaultBasePath
+    ),
   /**
    * Retrieve logs of a deployment for getting insight into the deployment results or failures.
    * @param deploymentId - Deployment identifier
@@ -207,6 +223,7 @@ export const DeploymentApi = {
         pathParameters: { deploymentId },
         queryParameters,
         headerParameters
-      }
+      },
+      DeploymentApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/docker-registry-secret-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/docker-registry-secret-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -18,6 +18,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const DockerRegistrySecretApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve the stored secret metadata which matches the parameter dockerRegistryName. The base64 encoded field for the stored secret is not returned.
    *
@@ -35,7 +36,8 @@ export const DockerRegistrySecretApi = {
       {
         pathParameters: { dockerRegistryName },
         headerParameters
-      }
+      },
+      DockerRegistrySecretApi._defaultBasePath
     ),
   /**
    * Update a secret with name of dockerRegistryName if it exists.
@@ -57,7 +59,8 @@ export const DockerRegistrySecretApi = {
         pathParameters: { dockerRegistryName },
         body,
         headerParameters
-      }
+      },
+      DockerRegistrySecretApi._defaultBasePath
     ),
   /**
    * Delete a secret with the name of dockerRegistryName if it exists.
@@ -75,7 +78,8 @@ export const DockerRegistrySecretApi = {
       {
         pathParameters: { dockerRegistryName },
         headerParameters
-      }
+      },
+      DockerRegistrySecretApi._defaultBasePath
     ),
   /**
    * Retrieve a list of metadata of the stored secrets
@@ -94,7 +98,8 @@ export const DockerRegistrySecretApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      DockerRegistrySecretApi._defaultBasePath
     ),
   /**
    * Create a secret based on the configuration in the request body.
@@ -115,6 +120,7 @@ export const DockerRegistrySecretApi = {
       {
         body,
         headerParameters
-      }
+      },
+      DockerRegistrySecretApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/executable-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/executable-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -10,6 +10,7 @@ import type { AiExecutableList, AiExecutable } from './schema/index.js';
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ExecutableApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of executables for a scenario. Filter by version ID, if required.
    *
@@ -30,7 +31,8 @@ export const ExecutableApi = {
         pathParameters: { scenarioId },
         queryParameters,
         headerParameters
-      }
+      },
+      ExecutableApi._defaultBasePath
     ),
   /**
    * Retrieve details about an executable identified by executableId belonging
@@ -52,6 +54,7 @@ export const ExecutableApi = {
       {
         pathParameters: { scenarioId, executableId },
         headerParameters
-      }
+      },
+      ExecutableApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/execution-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/execution-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -21,6 +21,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ExecutionApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of executions that match the specified filter criteria.
    * Filter criteria include a list of executableIds, a scenarioId, a configurationId, or a execution status.
@@ -51,10 +52,15 @@ export const ExecutionApi = {
     },
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<AiExecutionList>('get', '/lm/executions', {
-      queryParameters,
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<AiExecutionList>(
+      'get',
+      '/lm/executions',
+      {
+        queryParameters,
+        headerParameters
+      },
+      ExecutionApi._defaultBasePath
+    ),
   /**
    * Create an execution using the configuration specified by configurationId.
    * @param body - Request body.
@@ -71,7 +77,8 @@ export const ExecutionApi = {
       {
         body,
         headerParameters
-      }
+      },
+      ExecutionApi._defaultBasePath
     ),
   /**
    * Patch multiple executions' status to stopped or deleted.
@@ -89,7 +96,8 @@ export const ExecutionApi = {
       {
         body,
         headerParameters
-      }
+      },
+      ExecutionApi._defaultBasePath
     ),
   /**
    * Retrieve details for execution with executionId.
@@ -110,7 +118,8 @@ export const ExecutionApi = {
         pathParameters: { executionId },
         queryParameters,
         headerParameters
-      }
+      },
+      ExecutionApi._defaultBasePath
     ),
   /**
    * Update target status of the execution to stop an execution.
@@ -131,7 +140,8 @@ export const ExecutionApi = {
         pathParameters: { executionId },
         body,
         headerParameters
-      }
+      },
+      ExecutionApi._defaultBasePath
     ),
   /**
    * Mark the execution with executionId as deleted.
@@ -149,7 +159,8 @@ export const ExecutionApi = {
       {
         pathParameters: { executionId },
         headerParameters
-      }
+      },
+      ExecutionApi._defaultBasePath
     ),
   /**
    * Retrieve the number of available executions. The number can be filtered by
@@ -176,10 +187,15 @@ export const ExecutionApi = {
     },
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<number>('get', '/lm/executions/$count', {
-      queryParameters,
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<number>(
+      'get',
+      '/lm/executions/$count',
+      {
+        queryParameters,
+        headerParameters
+      },
+      ExecutionApi._defaultBasePath
+    ),
   /**
    * Retrieve logs of an execution for getting insight into the execution results or failures.
    * @param executionId - Execution identifier
@@ -204,6 +220,7 @@ export const ExecutionApi = {
         pathParameters: { executionId },
         queryParameters,
         headerParameters
-      }
+      },
+      ExecutionApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/execution-schedule-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/execution-schedule-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -18,6 +18,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ExecutionScheduleApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of execution schedules that match the specified filter criteria.
    * Filter criteria include executionScheduleStatus or a configurationId.
@@ -42,7 +43,8 @@ export const ExecutionScheduleApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ExecutionScheduleApi._defaultBasePath
     ),
   /**
    * Create an execution schedule using the configuration specified by configurationId, and schedule.
@@ -60,7 +62,8 @@ export const ExecutionScheduleApi = {
       {
         body,
         headerParameters
-      }
+      },
+      ExecutionScheduleApi._defaultBasePath
     ),
   /**
    * Retrieve details for execution schedule with executionScheduleId.
@@ -78,7 +81,8 @@ export const ExecutionScheduleApi = {
       {
         pathParameters: { executionScheduleId },
         headerParameters
-      }
+      },
+      ExecutionScheduleApi._defaultBasePath
     ),
   /**
    * Update details of an execution schedule
@@ -99,7 +103,8 @@ export const ExecutionScheduleApi = {
         pathParameters: { executionScheduleId },
         body,
         headerParameters
-      }
+      },
+      ExecutionScheduleApi._defaultBasePath
     ),
   /**
    * Delete the execution schedule with executionScheduleId.
@@ -117,7 +122,8 @@ export const ExecutionScheduleApi = {
       {
         pathParameters: { executionScheduleId },
         headerParameters
-      }
+      },
+      ExecutionScheduleApi._defaultBasePath
     ),
   /**
    * Retrieve the number of scheduled executions. The number can be filtered by
@@ -134,8 +140,13 @@ export const ExecutionScheduleApi = {
     },
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<number>('get', '/lm/executionSchedules/$count', {
-      queryParameters,
-      headerParameters
-    })
+    new OpenApiRequestBuilder<number>(
+      'get',
+      '/lm/executionSchedules/$count',
+      {
+        queryParameters,
+        headerParameters
+      },
+      ExecutionScheduleApi._defaultBasePath
+    )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/file-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/file-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -10,6 +10,7 @@ import type { DSetFileCreationResponse } from './schema/index.js';
  * This API is part of the 'AI_CORE_API' service.
  */
 export const FileApi = {
+  _defaultBasePath: undefined,
   /**
    * Endpoint for downloading file. The path must point to an individual file.
    * @param path - path relative to the object store root URL in the secret
@@ -20,10 +21,15 @@ export const FileApi = {
     path: string,
     headerParameters?: { 'AI-Resource-Group'?: string }
   ) =>
-    new OpenApiRequestBuilder<string>('get', '/lm/dataset/files/{path}', {
-      pathParameters: { path },
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<string>(
+      'get',
+      '/lm/dataset/files/{path}',
+      {
+        pathParameters: { path },
+        headerParameters
+      },
+      FileApi._defaultBasePath
+    ),
   /**
    * Endpoint for uploading file. The maximum file size depends on the actual implementation
    * but must not exceed 100MB. The actual file size limit can be obtained by querying
@@ -62,7 +68,8 @@ export const FileApi = {
         body,
         queryParameters,
         headerParameters
-      }
+      },
+      FileApi._defaultBasePath
     ),
   /**
    * Delete the file specified by the path parameter.
@@ -74,8 +81,13 @@ export const FileApi = {
     path: string,
     headerParameters?: { 'AI-Resource-Group'?: string }
   ) =>
-    new OpenApiRequestBuilder<any>('delete', '/lm/dataset/files/{path}', {
-      pathParameters: { path },
-      headerParameters
-    })
+    new OpenApiRequestBuilder<any>(
+      'delete',
+      '/lm/dataset/files/{path}',
+      {
+        pathParameters: { path },
+        headerParameters
+      },
+      FileApi._defaultBasePath
+    )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/index.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/kpi-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/kpi-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -10,6 +10,7 @@ import type { KpiResultSet, KpiColumnName } from './schema/index.js';
  * This API is part of the 'AI_CORE_API' service.
  */
 export const KPIApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve the number of executions, artifacts, and deployments
    * for each resource group, scenario, and executable. The columns to be returned can be specified in a query parameter.
@@ -18,7 +19,12 @@ export const KPIApi = {
    * @returns The request builder, use the `execute()` method to trigger the request.
    */
   kpiGet: (queryParameters?: { $select?: Set<KpiColumnName> }) =>
-    new OpenApiRequestBuilder<KpiResultSet>('get', '/analytics/kpis', {
-      queryParameters
-    })
+    new OpenApiRequestBuilder<KpiResultSet>(
+      'get',
+      '/analytics/kpis',
+      {
+        queryParameters
+      },
+      KPIApi._defaultBasePath
+    )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/meta-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/meta-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -10,9 +10,16 @@ import type { MetaCapabilities } from './schema/index.js';
  * This API is part of the 'AI_CORE_API' service.
  */
 export const MetaApi = {
+  _defaultBasePath: undefined,
   /**
    * Meta information about an implementation of AI API, describing its capabilities, limits and extensions
    * @returns The request builder, use the `execute()` method to trigger the request.
    */
-  metaGet: () => new OpenApiRequestBuilder<MetaCapabilities>('get', '/lm/meta')
+  metaGet: () =>
+    new OpenApiRequestBuilder<MetaCapabilities>(
+      'get',
+      '/lm/meta',
+      {},
+      MetaApi._defaultBasePath
+    )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/metrics-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/metrics-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -17,6 +17,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const MetricsApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve metrics, labels, or tags according to filter conditions.
    * One query parameter is mandatory, either execution ID or filter.
@@ -34,10 +35,15 @@ export const MetricsApi = {
     },
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<TrckGetMetricResourceList>('get', '/lm/metrics', {
-      queryParameters,
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<TrckGetMetricResourceList>(
+      'get',
+      '/lm/metrics',
+      {
+        queryParameters,
+        headerParameters
+      },
+      MetricsApi._defaultBasePath
+    ),
   /**
    * Update or create metrics, tags, or labels associated with an execution.
    *
@@ -49,10 +55,15 @@ export const MetricsApi = {
     body: TrckMetricResource,
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<any>('patch', '/lm/metrics', {
-      body,
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<any>(
+      'patch',
+      '/lm/metrics',
+      {
+        body,
+        headerParameters
+      },
+      MetricsApi._defaultBasePath
+    ),
   /**
    * Delete metrics, tags, or labels associated with an execution.
    * @param queryParameters - Object containing the following keys: executionId.
@@ -69,6 +80,7 @@ export const MetricsApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      MetricsApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/object-store-secret-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/object-store-secret-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -18,6 +18,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ObjectStoreSecretApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of metadata of the stored secrets.
    *
@@ -35,7 +36,8 @@ export const ObjectStoreSecretApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ObjectStoreSecretApi._defaultBasePath
     ),
   /**
    * Create a secret based on the configuration in the request body
@@ -54,7 +56,8 @@ export const ObjectStoreSecretApi = {
       {
         body,
         headerParameters
-      }
+      },
+      ObjectStoreSecretApi._defaultBasePath
     ),
   /**
    * This retrieves the metadata of the stored secret which match the parameter objectStoreName.
@@ -75,7 +78,8 @@ export const ObjectStoreSecretApi = {
       {
         pathParameters: { objectStoreName },
         headerParameters
-      }
+      },
+      ObjectStoreSecretApi._defaultBasePath
     ),
   /**
    * Update a secret with name of objectStoreName if it exists.
@@ -97,7 +101,8 @@ export const ObjectStoreSecretApi = {
         pathParameters: { objectStoreName },
         body,
         headerParameters
-      }
+      },
+      ObjectStoreSecretApi._defaultBasePath
     ),
   /**
    * Delete a secret with the name of objectStoreName if it exists.
@@ -115,6 +120,7 @@ export const ObjectStoreSecretApi = {
       {
         pathParameters: { objectStoreName },
         headerParameters
-      }
+      },
+      ObjectStoreSecretApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/repository-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/repository-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -18,6 +18,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const RepositoryApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of all GitOps repositories for a tenant.
    * @param queryParameters - Object containing the following keys: $top, $skip, $count.
@@ -34,7 +35,8 @@ export const RepositoryApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      RepositoryApi._defaultBasePath
     ),
   /**
    * On-board a new GitOps repository as specified in the content payload
@@ -52,7 +54,8 @@ export const RepositoryApi = {
       {
         body,
         headerParameters
-      }
+      },
+      RepositoryApi._defaultBasePath
     ),
   /**
    * Retrieve the access details for a repository if it exists.
@@ -70,7 +73,8 @@ export const RepositoryApi = {
       {
         pathParameters: { repositoryName },
         headerParameters
-      }
+      },
+      RepositoryApi._defaultBasePath
     ),
   /**
    * Update the referenced repository credentials to synchronize a repository.
@@ -92,7 +96,8 @@ export const RepositoryApi = {
         pathParameters: { repositoryName },
         body,
         headerParameters
-      }
+      },
+      RepositoryApi._defaultBasePath
     ),
   /**
    * Remove a repository from GitOps.
@@ -110,6 +115,7 @@ export const RepositoryApi = {
       {
         pathParameters: { repositoryName },
         headerParameters
-      }
+      },
+      RepositoryApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/resource-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/resource-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -14,6 +14,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ResourceApi = {
+  _defaultBasePath: undefined,
   /**
    * Lists all hot spare nodes, used nodes and total nodes corresponding to tenant.
    * @param headerParameters - Object containing the following keys: Authorization.
@@ -25,7 +26,8 @@ export const ResourceApi = {
       '/admin/resources/nodes',
       {
         headerParameters
-      }
+      },
+      ResourceApi._defaultBasePath
     ),
   /**
    * Set hot spare nodes corresponding to tenant at main tenant level.
@@ -43,6 +45,7 @@ export const ResourceApi = {
       {
         body,
         headerParameters
-      }
+      },
+      ResourceApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/resource-group-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/resource-group-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -17,6 +17,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ResourceGroupApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of resource groups for a given tenant.
    *
@@ -40,7 +41,8 @@ export const ResourceGroupApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ResourceGroupApi._defaultBasePath
     ),
   /**
    * Create resource group to a given main tenant. The length of resource group id must be between 3 and 253.
@@ -59,7 +61,8 @@ export const ResourceGroupApi = {
       {
         body,
         headerParameters
-      }
+      },
+      ResourceGroupApi._defaultBasePath
     ),
   /**
    * Get a resource group of a given main tenant.
@@ -78,7 +81,8 @@ export const ResourceGroupApi = {
       {
         pathParameters: { resourceGroupId },
         headerParameters
-      }
+      },
+      ResourceGroupApi._defaultBasePath
     ),
   /**
    * Replace some characteristics of the resource group, for instance labels.
@@ -100,7 +104,8 @@ export const ResourceGroupApi = {
         pathParameters: { resourceGroupId },
         body,
         headerParameters
-      }
+      },
+      ResourceGroupApi._defaultBasePath
     ),
   /**
    * Delete a resource group of a given main tenant.
@@ -119,6 +124,7 @@ export const ResourceGroupApi = {
       {
         pathParameters: { resourceGroupId },
         headerParameters
-      }
+      },
+      ResourceGroupApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/resource-quota-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/resource-quota-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -14,6 +14,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ResourceQuotaApi = {
+  _defaultBasePath: undefined,
   /**
    * Get the details about quota and usage for resource groups
    * @param queryParameters - Object containing the following keys: quotaOnly.
@@ -30,7 +31,8 @@ export const ResourceQuotaApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ResourceQuotaApi._defaultBasePath
     ),
   /**
    * Get the details about quota and usage for executables
@@ -48,7 +50,8 @@ export const ResourceQuotaApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ResourceQuotaApi._defaultBasePath
     ),
   /**
    * Get the details about quota and usage for applications
@@ -66,7 +69,8 @@ export const ResourceQuotaApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ResourceQuotaApi._defaultBasePath
     ),
   /**
    * Get the details about quota and usage for repositories
@@ -84,7 +88,8 @@ export const ResourceQuotaApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ResourceQuotaApi._defaultBasePath
     ),
   /**
    * Get the details about quota and usage for tenant-level generic secrets
@@ -102,7 +107,8 @@ export const ResourceQuotaApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ResourceQuotaApi._defaultBasePath
     ),
   /**
    * Get the details about quota and usage for docker registry secrets
@@ -120,7 +126,8 @@ export const ResourceQuotaApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ResourceQuotaApi._defaultBasePath
     ),
   /**
    * Get the details about quota and usage for deployments
@@ -138,6 +145,7 @@ export const ResourceQuotaApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      ResourceQuotaApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/scenario-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/scenario-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -15,15 +15,21 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ScenarioApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of all available scenarios.
    * @param headerParameters - Object containing the following keys: AI-Resource-Group.
    * @returns The request builder, use the `execute()` method to trigger the request.
    */
   scenarioQuery: (headerParameters: { 'AI-Resource-Group': string }) =>
-    new OpenApiRequestBuilder<AiScenarioList>('get', '/lm/scenarios', {
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<AiScenarioList>(
+      'get',
+      '/lm/scenarios',
+      {
+        headerParameters
+      },
+      ScenarioApi._defaultBasePath
+    ),
   /**
    * Retrieve details for a scenario specified by scenarioId.
    * @param scenarioId - Scenario identifier
@@ -34,10 +40,15 @@ export const ScenarioApi = {
     scenarioId: string,
     headerParameters: { 'AI-Resource-Group': string }
   ) =>
-    new OpenApiRequestBuilder<AiScenario>('get', '/lm/scenarios/{scenarioId}', {
-      pathParameters: { scenarioId },
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<AiScenario>(
+      'get',
+      '/lm/scenarios/{scenarioId}',
+      {
+        pathParameters: { scenarioId },
+        headerParameters
+      },
+      ScenarioApi._defaultBasePath
+    ),
   /**
    * Retrieve a list of scenario versions based on the versions of executables
    * available within that scenario.
@@ -59,7 +70,8 @@ export const ScenarioApi = {
         pathParameters: { scenarioId },
         queryParameters,
         headerParameters
-      }
+      },
+      ScenarioApi._defaultBasePath
     ),
   /**
    * Retrieve information about all models available in LLM global scenario
@@ -77,6 +89,7 @@ export const ScenarioApi = {
       {
         pathParameters: { scenarioId },
         headerParameters
-      }
+      },
+      ScenarioApi._defaultBasePath
     )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-api-error-with-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-api-error-with-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-api-error.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-api-error.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-argument-binding-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-argument-binding-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-argument-binding.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-argument-binding.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-array.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-array.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-creation-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-creation-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-description.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-description.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-name.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-name.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-post-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-post-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-url.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact-url.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-artifact.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-backend-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-backend-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-base-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-base-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-creation-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-creation-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-name.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration-name.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-configuration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-cron.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-cron.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-bulk-modification-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-bulk-modification-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-bulk-modification-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-bulk-modification-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-creation-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-creation-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-creation-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-creation-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-deletion-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-deletion-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-deletion-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-deletion-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-request-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-request-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-request-with-identifier.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-request-with-identifier.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-response-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-response-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-modification-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-response-with-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-response-with-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-status-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-status-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-status-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-status-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-status.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-status.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-target-status.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-target-status.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-time-to-live.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-time-to-live.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-url.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment-url.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-deployment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-enactment-creation-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-enactment-creation-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-artifact-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-artifact-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-artifact.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-artifact.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-parameter-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-parameter-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-parameter.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable-parameter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-executable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-bulk-modification-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-bulk-modification-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-bulk-modification-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-bulk-modification-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-creation-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-creation-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-deletion-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-deletion-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-deletion-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-deletion-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-request-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-request-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-request-with-identifier.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-request-with-identifier.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-response-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-response-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-modification-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-response-with-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-response-with-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-creation-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-creation-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-creation-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-creation-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-deletion-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-deletion-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-deletion-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-deletion-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-modification-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-modification-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-modification-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-modification-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-modification-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-modification-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-status.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule-status.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-schedule.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-status-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-status-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-status-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-status-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-status.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution-status.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-execution.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-label-key.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-label-key.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-label-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-label-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-label-value.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-label-value.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-label.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-label.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-log-common-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-log-common-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-log-common-result-item.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-log-common-result-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-log-common-result.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-log-common-result.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-model-base-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-model-base-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-model-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-model-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-model-version-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-model-version-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-model-version.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-model-version.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-parameter-argument-binding-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-parameter-argument-binding-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-parameter-argument-binding.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-parameter-argument-binding.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-resources-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-resources-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-scaling-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-scaling-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario-label-key.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario-label-key.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario-label-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario-label-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario-label.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario-label.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-scenario.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-url.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-url.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-version-description.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-version-description.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-version-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-version-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-version-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-version-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/ai-version.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/ai-version.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-all-argo-cd-application-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-all-argo-cd-application-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-base-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-base-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-creation-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-creation-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-data-repo-name.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-data-repo-name.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-deletion-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-deletion-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-deletion-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-deletion-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-modification-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-modification-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-modification-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-modification-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-refresh-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-refresh-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-refresh-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-refresh-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-status.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-application-status.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-creation-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-creation-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-credentials.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-credentials.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-data-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-data-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-deletion-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-deletion-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-deletion-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-deletion-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-modification-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-modification-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-modification-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-argo-cd-repository-modification-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-common-resource-quota-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-common-resource-quota-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-deployment-quota-item.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-deployment-quota-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-deployment-quota.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-deployment-quota.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-deployment-resource-quota-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-deployment-resource-quota-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-deployment-usage.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-deployment-usage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-error-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-error-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-error.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-error.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-event.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-event.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-executable-resource-quota-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-executable-resource-quota-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-extended-service.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-extended-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-generic-secret-data-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-generic-secret-data-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-generic-secret-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-generic-secret-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-generic-secret-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-generic-secret-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-generic-secret-patch-body.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-generic-secret-patch-body.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-generic-secret-post-body.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-generic-secret-post-body.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-internal-resource-group-annotation.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-internal-resource-group-annotation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-internal-resource-group-annotations.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-internal-resource-group-annotations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-internal-resource-group-label.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-internal-resource-group-label.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-internal-resource-group-labels.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-internal-resource-group-labels.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-internal-resource-group.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-internal-resource-group.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-list-generic-secrets-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-list-generic-secrets-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-name.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-name.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-get-resource-plans.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-get-resource-plans.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-get-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-get-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-base.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-base.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-deletion-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-deletion-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-deletion-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-deletion-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-label.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-label.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-labels.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-labels.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-patch-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group-patch-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-group.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-groups-post-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-groups-post-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-patch-body.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-patch-body.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-patch-nodes.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-patch-nodes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-patch-resource-plans.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-patch-resource-plans.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-patch-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-resource-patch-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-broker-secret.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-broker-secret.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-capabilities.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-capabilities.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-catalog-item-extend-catalog.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-catalog-item-extend-catalog.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-catalog-item-extend-credentials.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-catalog-item-extend-credentials.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-catalog-item.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-catalog-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-catalog.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-catalog.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-plan-item-metadata.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-plan-item-metadata.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-plan-item.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service-service-plan-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-tenant.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-tenant.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-url.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-url.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-usage-resource-plan-item.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknd-usage-resource-plan-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-name-component.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-name-component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-creation-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-creation-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-deletion-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-deletion-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-deletion-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-deletion-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-modification-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-modification-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-modification-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-modification-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-status-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-status-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-status.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-status.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-with-sensitive-data-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bcknddocker-registry-secret-with-sensitive-data-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-creation-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-creation-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-deletion-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-deletion-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-deletion-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-deletion-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-modification-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-modification-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-modification-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-modification-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-status-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-status-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-status.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-status.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-with-sensitive-data-request-for-post-call.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-with-sensitive-data-request-for-post-call.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-with-sensitive-data-request.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/bckndobject-store-secret-with-sensitive-data-request.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/d-set-error.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/d-set-error.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/d-set-file-creation-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/d-set-file-creation-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/d-set-url.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/d-set-url.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/index.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/kpi-aggregation-attribute.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/kpi-aggregation-attribute.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/kpi-api-error.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/kpi-api-error.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/kpi-array-of-column-names.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/kpi-array-of-column-names.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/kpi-column-name.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/kpi-column-name.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/kpi-count-aggregate.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/kpi-count-aggregate.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/kpi-result-row-item.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/kpi-result-row-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/kpi-result-row-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/kpi-result-row-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/kpi-result-row.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/kpi-result-row.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/kpi-result-set.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/kpi-result-set.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/meta-ai-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/meta-ai-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/meta-api-error.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/meta-api-error.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/meta-api-version.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/meta-api-version.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/meta-capabilities.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/meta-capabilities.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/meta-extensions.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/meta-extensions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/meta-version.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/meta-version.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rt-amessage.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rt-amessage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rt-atimestamp.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rt-atimestamp.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-array.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-array.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-label-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-label-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-label.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-label.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-name.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-name.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-signature.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-signature.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-url.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact-url.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-artifact.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-backend-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-backend-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-cascade-update-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-cascade-update-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-deletion-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-deletion-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-modification-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-modification-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-status-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-status-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-url.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment-url.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-deployment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-error-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-error-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-error.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-error.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-argument-binding.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-argument-binding.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-artifact.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-artifact.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-input-artifact-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-input-artifact-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-output-artifact-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-output-artifact-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-parameter-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-parameter-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-parameter.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable-parameter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-executable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution-creation-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution-creation-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution-deletion-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution-deletion-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution-modification-response-message.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution-modification-response-message.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution-status-details.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution-status-details.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-execution.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-input-artifact-argument-binding.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-input-artifact-argument-binding.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-label-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-label-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-label.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-label.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-latest-running-target-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-latest-running-target-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-log-common-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-log-common-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-log-common-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-log-common-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-log-common-result-item.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-log-common-result-item.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-log-common-result.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-log-common-result.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-model-base-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-model-base-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-model-version-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-model-version-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-model-version.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-model-version.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-output-artifact-argument-binding.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-output-artifact-argument-binding.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-scenario-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-scenario-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-scenario.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-scenario.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-target-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-target-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/rta-ttl.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/rta-ttl.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-api-error.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-api-error.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-custom-info-object-data.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-custom-info-object-data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-custom-info-object-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-custom-info-object-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-custom-info-object.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-custom-info-object.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-delete-metrics-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-delete-metrics-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-details-error-response.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-details-error-response.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-execution-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-execution-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-generic-name.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-generic-name.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-get-metric-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-get-metric-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-get-metric-resource-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-get-metric-resource-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-get-metric-resource.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-get-metric-resource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-get-metric.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-get-metric.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-label-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-label-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-label-name.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-label-name.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-label.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-label.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-metric-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-metric-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-metric-name.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-metric-name.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-metric-resource.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-metric-resource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-metric-value.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-metric-value.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-metric.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-metric.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-mlapi-execution-id.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-mlapi-execution-id.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-string-array.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-string-array.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-tag-list.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-tag-list.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-tag.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-tag.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trck-timestamp.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trck-timestamp.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/schema/trckmetric-selector-permissible-values.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/schema/trckmetric-selector-permissible-values.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/ai-api/src/client/AI_CORE_API/secret-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/secret-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -15,6 +15,7 @@ import type {
  * This API is part of the 'AI_CORE_API' service.
  */
 export const SecretApi = {
+  _defaultBasePath: undefined,
   /**
    * Lists all secrets corresponding to tenant. This retrieves metadata only, not the secret data itself.
    * @param queryParameters - Object containing the following keys: $top, $skip, $count.
@@ -35,7 +36,8 @@ export const SecretApi = {
       {
         queryParameters,
         headerParameters
-      }
+      },
+      SecretApi._defaultBasePath
     ),
   /**
    * Create a new generic secret in the corresponding resource group or at main tenant level.
@@ -57,7 +59,8 @@ export const SecretApi = {
       {
         body,
         headerParameters
-      }
+      },
+      SecretApi._defaultBasePath
     ),
   /**
    * Update secret credentials. Replace secret data with the provided data.
@@ -82,7 +85,8 @@ export const SecretApi = {
         pathParameters: { secretName },
         body,
         headerParameters
-      }
+      },
+      SecretApi._defaultBasePath
     ),
   /**
    * Deletes the secret from provided resource group namespace
@@ -98,8 +102,13 @@ export const SecretApi = {
       'AI-Tenant-Scope'?: boolean;
     }
   ) =>
-    new OpenApiRequestBuilder<any>('delete', '/admin/secrets/{secretName}', {
-      pathParameters: { secretName },
-      headerParameters
-    })
+    new OpenApiRequestBuilder<any>(
+      'delete',
+      '/admin/secrets/{secretName}',
+      {
+        pathParameters: { secretName },
+        headerParameters
+      },
+      SecretApi._defaultBasePath
+    )
 };

--- a/packages/ai-api/src/client/AI_CORE_API/service-api.ts
+++ b/packages/ai-api/src/client/AI_CORE_API/service-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
@@ -10,6 +10,7 @@ import type { BckndServiceList, BckndExtendedService } from './schema/index.js';
  * This API is part of the 'AI_CORE_API' service.
  */
 export const ServiceApi = {
+  _defaultBasePath: undefined,
   /**
    * Retrieve a list of services for a given main tenant.
    *
@@ -19,9 +20,14 @@ export const ServiceApi = {
   kubesubmitV4AiservicesGetAll: (headerParameters?: {
     Authorization?: string;
   }) =>
-    new OpenApiRequestBuilder<BckndServiceList>('get', '/admin/services', {
-      headerParameters
-    }),
+    new OpenApiRequestBuilder<BckndServiceList>(
+      'get',
+      '/admin/services',
+      {
+        headerParameters
+      },
+      ServiceApi._defaultBasePath
+    ),
   /**
    * Get an service of a given main tenant.
    *
@@ -39,6 +45,7 @@ export const ServiceApi = {
       {
         pathParameters: { serviceName },
         headerParameters
-      }
+      },
+      ServiceApi._defaultBasePath
     )
 };


### PR DESCRIPTION
## Context

~Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.~

## What this PR does and why it is needed

This PR regenerates the AI Core client after cloud sdk generator changes for accounting for a `basePath`.
As, we don't have anything that accounts for `basePath` in this spec, the regenerated clients have this property set to `undefined`.
