### PR TITLE
chore: Fix failing E2E test

### DIFF
--- a/sample-code/src/orchestration.ts
+++ b/sample-code/src/orchestration.ts
@@ -21,7 +21,8 @@ const logger = createLogger({
 });
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+// File lies in the dist folder when transpiled file executes, so we need to go up one level
+const __dirname = join(dirname(__filename), '..');
 
 /**
  * A simple LLM request, asking about the capital of France.


### PR DESCRIPTION
## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

Fix for failing Orchestration E2E test.
The [test](https://github.com/SAP/ai-sdk-js/actions/runs/13041295933/job/36383570016) is currently not able to resolve an image path: `no such file or directory, open '/home/runner/work/ai-sdk-js/ai-sdk-js/sample-code/dist/media/sample-image.png'`

I have fixed this by correcting the resolved directory name. Originally it pointed to the `sample-code/dist` folder as the transpiled code gets executed in the end, now it gets correctly resolved to the `sample-code` folder instead.