### PR TITLE
fix: Spec Update Workflow Permissions

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: sap/ai-sdk-js/.github/actions/setup@main
         with:
           node-version: 20
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
 
       - name: "Checkout or Create Branch"
         id: branch
@@ -134,7 +134,7 @@ jobs:
         id: create-pr
         if: ${{ env.CREATE_PR == 'true' && steps.spec_diff.outputs.spec_diff == 'true'}}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
           BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
           if gh pr list --head $BRANCH --json number -q '.[].number' | grep -q .; then


### PR DESCRIPTION
If we use the normal token, the created PRs will not trigger CI/CD runs