### PR TITLE
chore: Add new workflow for updating dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -1,0 +1,44 @@
+name: Update pnpm-lock.yaml for Dependabot PRs
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - '**/package.json'
+
+jobs:
+  update-lockfile:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # TODO: Read from variables instead
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10
+
+      - name: Update lockfile
+        run: pnpm install --lockfile-only
+
+      - name: Commit and push if changed
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config --global user.email "cloud-sdk-js@github.com"
+            git config --global user.name "cloud-sdk-js"  
+            git add pnpm-lock.yaml
+            git commit -m "chore: update pnpm-lock.yaml"
+            git push
+          fi

--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -16,16 +16,12 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup Environment
         uses: sap/ai-sdk-js/.github/actions/setup@main
         with:
-          node-version: '20' # TODO: Read from variables instead
-
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
+          
       - name: Update lockfile
         run: pnpm install --lockfile-only
 

--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [opened, synchronize]
     paths:
-      - 'package.json'
+
       - '**/package.json'
   workflow_dispatch:
 
@@ -23,14 +23,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: sap/ai-sdk-js/.github/actions/setup@main
         with:
           node-version: '20' # TODO: Read from variables instead
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10
 
       - name: Update lockfile
         run: pnpm install --lockfile-only

--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -4,7 +4,6 @@ on:
   pull_request_target:
     types: [opened, synchronize]
     paths:
-
       - '**/package.json'
   workflow_dispatch:
 
@@ -22,7 +21,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node.js
+      - name: Setup Environment
         uses: sap/ai-sdk-js/.github/actions/setup@main
         with:
           node-version: '20' # TODO: Read from variables instead

--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'package.json'
       - '**/package.json'
+  workflow_dispatch:
 
 jobs:
   update-lockfile:

--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -1,7 +1,8 @@
 name: Update pnpm-lock.yaml for Dependabot PRs
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
     paths:
       - 'package.json'
       - '**/package.json'


### PR DESCRIPTION
## Context

Adds a new workflow to update the `pnpm-lock.yaml` on dependabot PRs

## What this PR does and why it is needed

Dependabot PRs are not created with `pnpm v10`, hence we need an additional action to update the lock files generated with version 10 explicitly.

<!-- Please provide a description summarizing your changes and their rationale -->
