### PR TITLE
chore: Add region to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,6 +64,26 @@ body:
       required: false
   - type: dropdown
     attributes:
+      label: "Region"
+      description: "Choose the datacenter region where you encountered this issue."
+      multiple: false
+      options:
+        - AP10
+        - EU10 Canary
+        - EU10
+        - EU11
+        - EU12 Canary
+        - EU20
+        - EU30
+        - JP10
+        - US10
+        - US21
+        - US30
+        - SA30
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
       label: "Affected Development Phase"
       description: "Choose the development phase affected by this issue."
       multiple: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,8 +65,8 @@ body:
   - type: dropdown
     attributes:
       label: "Region"
-      description: "Choose the datacenter region where you encountered this issue."
-      multiple: false
+      description: "Choose the region of your AI Core service."
+      multiple: true
       options:
         - AP10
         - EU10 Canary
@@ -80,6 +80,7 @@ body:
         - US21
         - US30
         - SA30
+        - Not listed above
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#210.

## What this PR does and why it is needed

Adds a region field to the bug report template. The list of options were taken from:

- https://me.sap.com/notes/3485650 (Internally available resources)
- https://me.sap.com/notes/3437766 (Externally available resources)