### PR TITLE
fix: Include destinations in deployment id lookup

### DIFF
--- a/.changeset/purple-lizards-buy.md
+++ b/.changeset/purple-lizards-buy.md
@@ -1,0 +1,6 @@
+---
+'@sap-ai-sdk/foundation-models': minor
+'@sap-ai-sdk/ai-api': minor
+---
+
+[Fixed Issue] Consider destination when resolving deployment ids.

--- a/.changeset/purple-lizards-buy.md
+++ b/.changeset/purple-lizards-buy.md
@@ -1,6 +1,7 @@
 ---
 '@sap-ai-sdk/foundation-models': minor
 '@sap-ai-sdk/ai-api': minor
+'@sap-ai-sdk/orchestration': minor
 ---
 
 [Fixed Issue] Consider destination when resolving deployment ids.

--- a/packages/ai-api/src/utils/deployment-resolver.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.ts
@@ -141,7 +141,12 @@ export async function resolveDeploymentId(
 async function getAllDeployments(
   opts: DeploymentResolutionOptions
 ): Promise<AiDeployment[]> {
-  const { destination, scenarioId, executableId, resourceGroup = 'default' } = opts;
+  const {
+    destination,
+    scenarioId,
+    executableId,
+    resourceGroup = 'default'
+  } = opts;
   try {
     const { resources } = await DeploymentApi.deploymentQuery(
       {

--- a/packages/ai-api/src/utils/deployment-resolver.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.ts
@@ -4,6 +4,7 @@ import {
 } from '../client/AI_CORE_API/index.js';
 import { deploymentCache } from './deployment-cache.js';
 import { extractModel, type FoundationModel } from './model.js';
+import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 
 /**
  * The model deployment configuration when using a model.
@@ -93,6 +94,10 @@ export interface DeploymentResolutionOptions {
    * The resource group of the deployment.
    */
   resourceGroup?: string;
+  /**
+   * The destination to use for the request.
+   */
+  destination?: HttpDestinationOrFetchOptions;
 }
 
 /**
@@ -136,7 +141,7 @@ export async function resolveDeploymentId(
 async function getAllDeployments(
   opts: DeploymentResolutionOptions
 ): Promise<AiDeployment[]> {
-  const { scenarioId, executableId, resourceGroup = 'default' } = opts;
+  const { destination, scenarioId, executableId, resourceGroup = 'default' } = opts;
   try {
     const { resources } = await DeploymentApi.deploymentQuery(
       {
@@ -145,7 +150,7 @@ async function getAllDeployments(
         ...(executableId && { executableIds: [executableId] })
       },
       { 'AI-Resource-Group': resourceGroup }
-    ).execute();
+    ).execute(destination);
 
     deploymentCache.setAll(opts, resources);
 
@@ -164,7 +169,8 @@ async function getAllDeployments(
  */
 export async function getDeploymentId(
   modelDeployment: ModelDeployment,
-  executableId: string
+  executableId: string,
+  destination?: HttpDestinationOrFetchOptions
 ): Promise<string> {
   if (isDeploymentIdConfig(modelDeployment)) {
     return modelDeployment.deploymentId;
@@ -179,7 +185,8 @@ export async function getDeploymentId(
     scenarioId: 'foundation-models',
     executableId,
     model: translateToFoundationModel(model),
-    resourceGroup: model.resourceGroup
+    resourceGroup: model.resourceGroup,
+    destination
   });
 }
 

--- a/packages/foundation-models/src/azure-openai/azure-openai-chat-client.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-chat-client.ts
@@ -70,7 +70,8 @@ export class AzureOpenAiChatClient {
   ): Promise<HttpResponse> {
     const deploymentId = await getDeploymentId(
       this.modelDeployment,
-      'azure-openai'
+      'azure-openai',
+      this.destination
     );
     const resourceGroup = getResourceGroup(this.modelDeployment);
     return executeRequest(

--- a/packages/foundation-models/src/azure-openai/azure-openai-embedding-client.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-embedding-client.ts
@@ -35,7 +35,8 @@ export class AzureOpenAiEmbeddingClient {
   ): Promise<AzureOpenAiEmbeddingResponse> {
     const deploymentId = await getDeploymentId(
       this.modelDeployment,
-      'azure-openai'
+      'azure-openai',
+      this.destination
     );
     const resourceGroup = getResourceGroup(this.modelDeployment);
     const response = await executeRequest(

--- a/packages/orchestration/src/orchestration-client.ts
+++ b/packages/orchestration/src/orchestration-client.ts
@@ -105,7 +105,8 @@ export class OrchestrationClient {
 
     const deploymentId = await resolveDeploymentId({
       scenarioId: 'orchestration',
-      ...(this.deploymentConfig ?? {})
+      ...(this.deploymentConfig ?? {}),
+      destination: this.destination
     });
 
     return executeRequest(


### PR DESCRIPTION
## Context

We ignored destinations in our deployment id lookup and only included it in the requests we execute.
With this PR, we also do the look-up flow based on the destination (if any was provided).

Relates to #547 

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
