### PR TITLE
feat: Add convenience function for LlamaGuard Filter

### DIFF
--- a/.changeset/hip-tools-smile.md
+++ b/.changeset/hip-tools-smile.md
@@ -2,4 +2,4 @@
 '@sap-ai-sdk/orchestration': minor
 ---
 
-[New Functionalities] Introduce `buildLlamaGuardFilter()` method to enable providing Llama guard content filters to the input and output filter configuration of the orchestration client.
+[New Functionality] Introduce `buildLlamaGuardFilter()` method to enable providing Llama guard content filters to the input and output filter configuration of the orchestration client.

--- a/.changeset/hip-tools-smile.md
+++ b/.changeset/hip-tools-smile.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/orchestration': minor
+---
+
+[New Functionalities] Introduce `buildLlamaGuardFilter()` method to enable providing Llama guard content filters to the input and output filter configuration of the orchestration client.

--- a/.changeset/hip-tools-smile.md
+++ b/.changeset/hip-tools-smile.md
@@ -2,4 +2,4 @@
 '@sap-ai-sdk/orchestration': minor
 ---
 
-[New Functionality] Introduce `buildLlamaGuardFilter()` function to enable providing Llama guard content filters to the input and output filter configuration of the orchestration client.
+[New Functionality] Introduce `buildLlamaGuardFilter()` convenience function to build Llama guard filters.

--- a/.changeset/hip-tools-smile.md
+++ b/.changeset/hip-tools-smile.md
@@ -2,4 +2,4 @@
 '@sap-ai-sdk/orchestration': minor
 ---
 
-[New Functionality] Introduce `buildLlamaGuardFilter()` method to enable providing Llama guard content filters to the input and output filter configuration of the orchestration client.
+[New Functionality] Introduce `buildLlamaGuardFilter()` function to enable providing Llama guard content filters to the input and output filter configuration of the orchestration client.

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -389,8 +389,6 @@ Each category of the filter can be assigned a specific severity level, which cor
 | `ALLOW_SAFE_LOW_MEDIUM` | 4                     |
 | `ALLOW_ALL`             | 6                     |
 
-The following example demonstrates how to build an Azure content filter with specific severity levels for each category.
-
 ```ts
 const filter = buildAzureContentSafetyFilter({
   Hate: 'ALLOW_SAFE_LOW',
@@ -404,8 +402,6 @@ Use `buildLlamaGuardFilter()` function to build a Llama Guard content filter.
 
 Available categories can be found with autocompletion.
 Pass the categories as arguments to the function to enable them.
-
-The following example demonstrates how to build a Llama Guard content filter with specific categories enabled.
 
 ```ts
 const filter = buildLlamaGuardFilter('hate', 'violent_crimes');

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -403,8 +403,7 @@ const filter = buildAzureContentSafetyFilter({
 Use `buildLlamaGuardFilter()` function to build a Llama Guard content filter.
 
 Available categories can be found with autocompletion.
-By default, all categories are disabled.
-Pass the categories you want as arguments to the function to enable them.
+Pass the categories as arguments to the function to enable them.
 
 The following example demonstrates how to build a Llama Guard content filter with specific categories enabled.
 

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -349,7 +349,7 @@ Each category of the filter can be assigned a specific severity level, which cor
 | `ALLOW_ALL`             | 6                     |
 
 ```ts
-import { OrchestrationClient, ContentFilters } from '@sap-ai-sdk/orchestration';
+import { OrchestrationClient } from '@sap-ai-sdk/orchestration';
 const llm = {
   model_name: 'gpt-4o',
   model_params: { max_tokens: 50, temperature: 0.1 }
@@ -383,6 +383,81 @@ try {
 } catch (error: any) {
   return `Error: ${error.message}`;
 }
+```
+
+#### Llama Guard Filter
+
+Use `buildLlamaGuardFilter()` function to build a Llama Guard content filter for both input and output.
+
+There are up to 14 categories that can be enabled for filtering by passing them as arguments to the `buildLlamaGuardFilter()` function.
+Use the IDE's autocompletion feature to discover all available categories.
+Any categories that are not included are disabled by default.
+
+```ts
+import { OrchestrationClient } from '@sap-ai-sdk/orchestration';
+const llm = {
+  model_name: 'gpt-4o',
+  model_params: { max_tokens: 50, temperature: 0.1 }
+};
+const templating = {
+  template: [{ role: 'user', content: '{{?input}}' }]
+};
+
+const filter = buildLlamaGuardFilter('hate', 'violent_crimes');
+const orchestrationClient = new OrchestrationClient({
+  llm,
+  templating,
+  filtering: {
+    input: {
+      filters: [filter]
+    },
+    output: {
+      filters: [filter]
+    }
+  }
+});
+
+try {
+  const response = await orchestrationClient.chatCompletion({
+    inputParams: { input: 'I hate you!' }
+  });
+  return response.getContent();
+} catch (error: any) {
+  return `Error: ${error.message}`;
+}
+```
+
+##### Using Multiple Content Filters
+
+Multiple different content filters can be passed into input and output filtering configuration of the orchestration client to further restrict the content that is passed to and received from a generative AI model.
+
+```ts
+import { OrchestrationClient } from '@sap-ai-sdk/orchestration';
+const llm = {
+  model_name: 'gpt-4o',
+  model_params: { max_tokens: 50, temperature: 0.1 }
+};
+const templating = {
+  template: [{ role: 'user', content: '{{?input}}' }]
+};
+
+const azureFilter = buildAzureContentSafetyFilter({
+  Hate: 'ALLOW_SAFE_LOW',
+  Violence: 'ALLOW_SAFE_LOW_MEDIUM'
+});
+const llamaGuardfilter = buildLlamaGuardFilter('hate', 'violent_crimes');
+const orchestrationClient = new OrchestrationClient({
+  llm,
+  templating,
+  filtering: {
+    input: {
+      filters: [azureFilter,llamaGuardfilter]
+    },
+    output: {
+      filters: [azureFilter,llamaGuardfilter]
+    }
+  }
+});
 ```
 
 #### Error Handling

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -451,10 +451,10 @@ const orchestrationClient = new OrchestrationClient({
   templating,
   filtering: {
     input: {
-      filters: [azureFilter,llamaGuardfilter]
+      filters: [azureFilter, llamaGuardfilter]
     },
     output: {
-      filters: [azureFilter,llamaGuardfilter]
+      filters: [azureFilter, llamaGuardfilter]
     }
   }
 });

--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -24,6 +24,7 @@ export { OrchestrationClient } from './orchestration-client.js';
 export {
   buildAzureContentFilter,
   buildAzureContentSafetyFilter,
+  buildLlamaGuardFilter,
   buildDocumentGroundingConfig
 } from './util/index.js';
 

--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -9,6 +9,7 @@ export type {
   DocumentGroundingServiceConfig,
   DocumentGroundingServiceFilter,
   LlmModelParams,
+  LlamaGuardCategory,
   AzureContentFilter,
   AzureFilterThreshold
 } from './orchestration-types.js';

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -8,6 +8,7 @@ import type {
   FilteringStreamOptions,
   GlobalStreamOptions,
   GroundingModuleConfig,
+  LlamaGuard38B,
   MaskingModuleConfig,
   LlmModuleConfig as OriginalLlmModuleConfig,
   TemplatingModuleConfig
@@ -201,3 +202,8 @@ export const supportedAzureFilterThresholds = {
  *
  */
 export type AzureFilterThreshold = keyof typeof supportedAzureFilterThresholds;
+
+/**
+ * The filter categories supported for Llama guard filter.
+ */
+export type LlamaGuardCategory = keyof LlamaGuard38B;

--- a/packages/orchestration/src/util/filtering.test.ts
+++ b/packages/orchestration/src/util/filtering.test.ts
@@ -1,6 +1,7 @@
 import {
   buildAzureContentFilter,
-  buildAzureContentSafetyFilter
+  buildAzureContentSafetyFilter,
+  buildLlamaGuardFilter
 } from './filtering.js';
 import { constructCompletionPostRequest } from './module-config.js';
 import type { OrchestrationModuleConfig } from '../orchestration-types.js';
@@ -209,6 +210,35 @@ describe('Content filter util', () => {
       expect(() => buildAzureContentSafetyFilter({})).toThrow(
         'Filtering configuration cannot be an empty object'
       );
+    });
+  });
+
+  describe('Llama Guard filter', () => {
+    it('builds filter config with custom config', async () => {
+      const filterConfig = buildLlamaGuardFilter({
+        child_exploitation: false,
+        hate: true,
+        violent_crimes: false,
+        sexual_content: true
+      });
+      const expectedFilterConfig = {
+        type: 'llama_guard_3_8b',
+        config: {
+          hate: true,
+          violent_crimes: false,
+          sexual_content: true
+        }
+      };
+      expect(filterConfig).toEqual(expectedFilterConfig);
+    });
+
+    it('builds filter config with no config', async () => {
+      const filterConfig = buildLlamaGuardFilter();
+      const expectedFilterConfig = {
+        type: 'llama_guard_3_8b',
+        config: {}
+      };
+      expect(filterConfig).toEqual(expectedFilterConfig);
     });
   });
 });

--- a/packages/orchestration/src/util/filtering.test.ts
+++ b/packages/orchestration/src/util/filtering.test.ts
@@ -225,7 +225,6 @@ describe('Content filter util', () => {
         type: 'llama_guard_3_8b',
         config: {
           hate: true,
-          violent_crimes: false,
           sexual_content: true
         }
       };
@@ -236,7 +235,22 @@ describe('Content filter util', () => {
       const filterConfig = buildLlamaGuardFilter();
       const expectedFilterConfig = {
         type: 'llama_guard_3_8b',
-        config: {}
+        config: {
+          violent_crimes: false,
+          non_violent_crimes: false,
+          sex_crimes: false,
+          child_exploitation: false,
+          defamation: false,
+          specialized_advice: false,
+          privacy: false,
+          intellectual_property: false,
+          indiscriminate_weapons: false,
+          hate: false,
+          self_harm: false,
+          sexual_content: false,
+          elections: false,
+          code_interpreter_abuse: false
+        }
       };
       expect(filterConfig).toEqual(expectedFilterConfig);
     });

--- a/packages/orchestration/src/util/filtering.test.ts
+++ b/packages/orchestration/src/util/filtering.test.ts
@@ -225,7 +225,9 @@ describe('Content filter util', () => {
         type: 'llama_guard_3_8b',
         config: {
           hate: true,
-          sexual_content: true
+          violent_crimes: false,
+          sexual_content: true,
+          child_exploitation: false
         }
       };
       expect(filterConfig).toEqual(expectedFilterConfig);

--- a/packages/orchestration/src/util/filtering.test.ts
+++ b/packages/orchestration/src/util/filtering.test.ts
@@ -216,18 +216,14 @@ describe('Content filter util', () => {
   describe('Llama Guard filter', () => {
     it('builds filter config with custom config', async () => {
       const filterConfig = buildLlamaGuardFilter({
-        child_exploitation: false,
         hate: true,
-        violent_crimes: false,
         sexual_content: true
       });
       const expectedFilterConfig = {
         type: 'llama_guard_3_8b',
         config: {
           hate: true,
-          violent_crimes: false,
-          sexual_content: true,
-          child_exploitation: false
+          sexual_content: true
         }
       };
       expect(filterConfig).toEqual(expectedFilterConfig);

--- a/packages/orchestration/src/util/filtering.test.ts
+++ b/packages/orchestration/src/util/filtering.test.ts
@@ -215,39 +215,28 @@ describe('Content filter util', () => {
 
   describe('Llama Guard filter', () => {
     it('builds filter config with custom config', async () => {
-      const filterConfig = buildLlamaGuardFilter({
-        hate: true,
-        sexual_content: true
-      });
+      const filterConfig = buildLlamaGuardFilter('elections', 'hate');
       const expectedFilterConfig = {
         type: 'llama_guard_3_8b',
         config: {
-          hate: true,
-          sexual_content: true
+          elections: true,
+          hate: true
         }
       };
       expect(filterConfig).toEqual(expectedFilterConfig);
     });
 
-    it('builds filter config with no config', async () => {
-      const filterConfig = buildLlamaGuardFilter();
+    it('builds filter config without duplicates', async () => {
+      const filterConfig = buildLlamaGuardFilter(
+        'non_violent_crimes',
+        'privacy',
+        'non_violent_crimes'
+      );
       const expectedFilterConfig = {
         type: 'llama_guard_3_8b',
         config: {
-          violent_crimes: false,
-          non_violent_crimes: false,
-          sex_crimes: false,
-          child_exploitation: false,
-          defamation: false,
-          specialized_advice: false,
-          privacy: false,
-          intellectual_property: false,
-          indiscriminate_weapons: false,
-          hate: false,
-          self_harm: false,
-          sexual_content: false,
-          elections: false,
-          code_interpreter_abuse: false
+          non_violent_crimes: true,
+          privacy: true
         }
       };
       expect(filterConfig).toEqual(expectedFilterConfig);

--- a/packages/orchestration/src/util/filtering.ts
+++ b/packages/orchestration/src/util/filtering.ts
@@ -82,7 +82,7 @@ const defaultLlamaGuardConfig: LlamaGuard38B = {
 };
 
 /**
- * Convenience function to create Azure content filters.
+ * Convenience function to create Llama guard filters.
  * @param config - Configuration for Llama guard filter.
  * @returns Filter config object.
  */

--- a/packages/orchestration/src/util/filtering.ts
+++ b/packages/orchestration/src/util/filtering.ts
@@ -13,7 +13,7 @@ import type {
 } from '../orchestration-types.js';
 
 /**
- * Convenience function to create Azure content filters.
+ * Convenience function to build Azure content filter.
  * @param filter - Filtering configuration for Azure filter. If skipped, the default Azure content filter configuration is used.
  * @returns An object with the Azure filtering configuration.
  * @deprecated Since 1.8.0. Use {@link buildAzureContentSafetyFilter()} instead.
@@ -35,10 +35,11 @@ export function buildAzureContentFilter(
 }
 
 /**
- * Convenience function to create Azure content filters.
+ * Convenience function to build Azure content filter.
  * @param config - Configuration for Azure content safety filter.
  * If skipped, the default configuration of `ALLOW_SAFE_LOW` is used for all filter categories.
  * @returns Filter config object.
+ * @example "buildAzureContentSafetyFilter({ Hate: 'ALLOW_SAFE', Violence: 'ALLOW_SAFE_LOW_MEDIUM' })"
  */
 export function buildAzureContentSafetyFilter(
   config?: AzureContentFilter
@@ -62,9 +63,10 @@ export function buildAzureContentSafetyFilter(
 }
 
 /**
- * Convenience function to create Llama guard filters.
- * @param categories - Categories to be enabled for filtering. A minimum of one category must be provided.
+ * Convenience function to build Llama guard filter.
+ * @param categories - Categories to be enabled for filtering. At least one category must be provided.
  * @returns Filter config object.
+ * @example "buildLlamaGuardFilter('self_harm', 'hate')"
  */
 export function buildLlamaGuardFilter(
   ...categories: [LlamaGuardCategory, ...LlamaGuardCategory[]]

--- a/packages/orchestration/src/util/filtering.ts
+++ b/packages/orchestration/src/util/filtering.ts
@@ -3,13 +3,13 @@ import type {
   AzureContentSafety,
   AzureContentSafetyFilterConfig,
   InputFilteringConfig,
-  LlamaGuard38B,
   LlamaGuard38BFilterConfig,
   OutputFilteringConfig
 } from '../client/api/schema/index.js';
 import type {
   AzureContentFilter,
-  AzureFilterThreshold
+  AzureFilterThreshold,
+  LlamaGuardCategory
 } from '../orchestration-types.js';
 
 /**
@@ -62,38 +62,17 @@ export function buildAzureContentSafetyFilter(
 }
 
 /**
- * @internal
- */
-const defaultLlamaGuardConfig: LlamaGuard38B = {
-  violent_crimes: false,
-  non_violent_crimes: false,
-  sex_crimes: false,
-  child_exploitation: false,
-  defamation: false,
-  specialized_advice: false,
-  privacy: false,
-  intellectual_property: false,
-  indiscriminate_weapons: false,
-  hate: false,
-  self_harm: false,
-  sexual_content: false,
-  elections: false,
-  code_interpreter_abuse: false
-};
-
-/**
  * Convenience function to create Llama guard filters.
- * @param config - Configuration for Llama guard filter.
+ * @param categories - Categories to be enabled for filtering. A minimum of one category must be provided.
  * @returns Filter config object.
  */
 export function buildLlamaGuardFilter(
-  config?: LlamaGuard38B
+  ...categories: [LlamaGuardCategory, ...LlamaGuardCategory[]]
 ): LlamaGuard38BFilterConfig {
-  if (config && !Object.keys(config).length) {
-    throw new Error('Filtering configuration cannot be an empty object');
-  }
   return {
     type: 'llama_guard_3_8b',
-    config: config ?? defaultLlamaGuardConfig
+    config: Object.fromEntries(
+      [...categories].map(category => [category, true])
+    )
   };
 }

--- a/packages/orchestration/src/util/filtering.ts
+++ b/packages/orchestration/src/util/filtering.ts
@@ -3,6 +3,8 @@ import type {
   AzureContentSafety,
   AzureContentSafetyFilterConfig,
   InputFilteringConfig,
+  LlamaGuard38B,
+  LlamaGuard38BFilterConfig,
   OutputFilteringConfig
 } from '../client/api/schema/index.js';
 import type {
@@ -56,5 +58,19 @@ export function buildAzureContentSafetyFilter(
         )
       }
     })
+  };
+}
+
+/**
+ * Convenience function to create Azure content filters.
+ * @param config - Configuration for Llama guard filter.
+ * @returns Filter config object.
+ */
+export function buildLlamaGuardFilter(
+  config?: LlamaGuard38B
+): LlamaGuard38BFilterConfig {
+  return {
+    type: 'llama_guard_3_8b',
+    config: config ?? {}
   };
 }

--- a/packages/orchestration/src/util/filtering.ts
+++ b/packages/orchestration/src/util/filtering.ts
@@ -61,6 +61,23 @@ export function buildAzureContentSafetyFilter(
   };
 }
 
+const defaultLlamaGuardConfig: LlamaGuard38B = {
+  violent_crimes: false,
+  non_violent_crimes: false,
+  sex_crimes: false,
+  child_exploitation: false,
+  defamation: false,
+  specialized_advice: false,
+  privacy: false,
+  intellectual_property: false,
+  indiscriminate_weapons: false,
+  hate: false,
+  self_harm: false,
+  sexual_content: false,
+  elections: false,
+  code_interpreter_abuse: false
+};
+
 /**
  * Convenience function to create Azure content filters.
  * @param config - Configuration for Llama guard filter.
@@ -69,8 +86,11 @@ export function buildAzureContentSafetyFilter(
 export function buildLlamaGuardFilter(
   config?: LlamaGuard38B
 ): LlamaGuard38BFilterConfig {
+  if (config && !Object.keys(config).length) {
+    throw new Error('Filtering configuration cannot be an empty object');
+  }
   return {
     type: 'llama_guard_3_8b',
-    config: config ?? {}
+    config: config ?? defaultLlamaGuardConfig
   };
 }

--- a/packages/orchestration/src/util/filtering.ts
+++ b/packages/orchestration/src/util/filtering.ts
@@ -61,6 +61,9 @@ export function buildAzureContentSafetyFilter(
   };
 }
 
+/**
+ * @internal
+ */
 const defaultLlamaGuardConfig: LlamaGuard38B = {
   violent_crimes: false,
   non_violent_crimes: false,

--- a/packages/orchestration/src/util/filtering.ts
+++ b/packages/orchestration/src/util/filtering.ts
@@ -64,7 +64,7 @@ export function buildAzureContentSafetyFilter(
 
 /**
  * Convenience function to build Llama guard filter.
- * @param categories - Categories to be enabled for filtering. At least one category must be provided.
+ * @param categories - Categories to be enabled for filtering. Provide at least one category.
  * @returns Filter config object.
  * @example "buildLlamaGuardFilter('self_harm', 'hate')"
  */

--- a/sample-code/src/orchestration.ts
+++ b/sample-code/src/orchestration.ts
@@ -209,7 +209,7 @@ export async function orchestrationInputFiltering(): Promise<void> {
  */
 export async function orchestrationOutputFiltering(): Promise<OrchestrationResponse> {
   // output filters are built in the same way as input filters
-  // set the threshold to the minimum to maximize the chance the LLM output will be filtered
+  // set the thresholds to the minimum to maximize the chance the LLM output will be filtered
   const azureContentFilter = buildAzureContentSafetyFilter({
     Hate: 'ALLOW_SAFE',
     Violence: 'ALLOW_SAFE'

--- a/test-util/data/orchestration/orchestration-chat-completion-multiple-filter-config.json
+++ b/test-util/data/orchestration/orchestration-chat-completion-multiple-filter-config.json
@@ -1,0 +1,82 @@
+{
+  "request_id": "anonymized-request-id",
+  "module_results": {
+    "templating": [
+      {
+        "role": "user",
+        "content": "Create 20 paraphrases of I like myself."
+      }
+    ],
+    "input_filtering": {
+      "message": "Input filter passed successfully.",
+      "data": {
+        "azure_content_safety": {
+          "Sexual": 0
+        },
+        "llama_guard_3_8b": {
+          "self_harm": false
+        }
+      }
+    },
+    "llm": {
+      "id": "anonymized-id",
+      "object": "chat.completion",
+      "created": 0,
+      "model": "gpt-35-turbo-16k",
+      "system_fingerprint": "anonymized-fingerprint",
+      "choices": [
+        {
+          "index": 0,
+          "message": {
+            "role": "assistant",
+            "content": "1. I have a positive opinion of myself.\n2. I have a strong sense of self-liking.\n3. I have a fondness for who I am.\n4. I am content with my own being.\n5. I have a"
+          },
+          "finish_reason": "length"
+        }
+      ],
+      "usage": {
+        "completion_tokens": 50,
+        "prompt_tokens": 17,
+        "total_tokens": 67
+      }
+    },
+    "output_filtering": {
+      "message": "0 of 1 choices failed the output filter.",
+      "data": {
+        "choices": [
+          {
+            "index": 0,
+            "azure_content_safety": {
+              "Sexual": 0
+            },
+            "llama_guard_3_8b": {
+              "self_harm": false
+            }
+          }
+        ]
+      }
+    }
+  },
+  "orchestration_result": {
+    "id": "anonymized-id",
+    "object": "chat.completion",
+    "created": 0,
+    "model": "gpt-35-turbo-16k",
+    "system_fingerprint": "anonymized-fingerprint",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "1. I have a positive opinion of myself.\n2. I have a strong sense of self-liking.\n3. I have a fondness for who I am.\n4. I am content with my own being.\n5. I have a"
+        },
+        "finish_reason": "length"
+      }
+    ],
+    "usage": {
+      "completion_tokens": 50,
+      "prompt_tokens": 17,
+      "total_tokens": 67
+    }
+  }
+}

--- a/tests/type-tests/test/orchestration.test-d.ts
+++ b/tests/type-tests/test/orchestration.test-d.ts
@@ -278,9 +278,7 @@ expectType<LlamaGuard38BFilterConfig>(
 
 expectError<LlamaGuard38BFilterConfig>(buildLlamaGuardFilter());
 
-expectError<LlamaGuard38BFilterConfig>(
-  buildLlamaGuardFilter('unknown-string')
-);
+expectError<LlamaGuard38BFilterConfig>(buildLlamaGuardFilter('unknown-string'));
 
 /**
  * Grounding util.

--- a/tests/type-tests/test/orchestration.test-d.ts
+++ b/tests/type-tests/test/orchestration.test-d.ts
@@ -2,7 +2,8 @@ import { expectError, expectType, expectAssignable } from 'tsd';
 import {
   OrchestrationClient,
   buildAzureContentSafetyFilter,
-  buildDocumentGroundingConfig
+  buildDocumentGroundingConfig,
+  buildLlamaGuardFilter
 } from '@sap-ai-sdk/orchestration';
 import type {
   CompletionPostResponse,
@@ -11,7 +12,8 @@ import type {
   ChatModel,
   GroundingModuleConfig,
   LlmModelParams,
-  AzureContentSafetyFilterConfig
+  AzureContentSafetyFilterConfig,
+  LlamaGuard38BFilterConfig
 } from '@sap-ai-sdk/orchestration';
 
 /**
@@ -247,7 +249,7 @@ expect<ChatModel>('custom-model');
 expect<ChatModel>('gemini-1.0-pro');
 
 /**
- * Filtering Util.
+ * Filtering Util for Azure content safety.
  */
 
 expectType<AzureContentSafetyFilterConfig>(
@@ -264,6 +266,20 @@ expectError<AzureContentSafetyFilterConfig>(
     Hate: 2,
     SelfHarm: 4
   })
+);
+
+/**
+ * Filtering Util for Llama guard.
+ */
+
+expectType<LlamaGuard38BFilterConfig>(
+  buildLlamaGuardFilter('code_interpreter_abuse', 'defamation')
+);
+
+expectError<LlamaGuard38BFilterConfig>(buildAzureContentSafetyFilter());
+
+expectError<LlamaGuard38BFilterConfig>(
+  buildAzureContentSafetyFilter('unknown-string')
 );
 
 /**

--- a/tests/type-tests/test/orchestration.test-d.ts
+++ b/tests/type-tests/test/orchestration.test-d.ts
@@ -276,10 +276,10 @@ expectType<LlamaGuard38BFilterConfig>(
   buildLlamaGuardFilter('code_interpreter_abuse', 'defamation')
 );
 
-expectError<LlamaGuard38BFilterConfig>(buildAzureContentSafetyFilter());
+expectError<LlamaGuard38BFilterConfig>(buildLlamaGuardFilter());
 
 expectError<LlamaGuard38BFilterConfig>(
-  buildAzureContentSafetyFilter('unknown-string')
+  buildLlamaGuardFilter('unknown-string')
 );
 
 /**


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#205.

## What this PR does and why it is needed

This PR adds a convenience function to enable filter categories for Llama guard filter.

<img width="880" alt="Screenshot 2025-02-20 at 14 41 31" src="https://github.com/user-attachments/assets/2007b056-5e00-413a-b498-9114aa5d7556" />

The built filter can then be used in the filtering configuration of the Orchestration client.

<!-- Please provide a description summarizing your changes and their rationale -->
