### PR TITLE
fix: E2E test typo

### DIFF
--- a/tests/e2e-tests/src/orchestration.test.ts
+++ b/tests/e2e-tests/src/orchestration.test.ts
@@ -94,7 +94,7 @@ describe('orchestration', () => {
 
   it('should return a response with tool_calls when finish_reason is tool_calls', async () => {
     const result = await orchestrationToolCalling();
-    expect(result.getFinishReason()).toBe('tools_calls');
+    expect(result.getFinishReason()).toBe('tool_calls');
 
     const tool_calls =
       result.data.orchestration_result.choices[0].message.tool_calls;


### PR DESCRIPTION
## What this PR does and why it is needed

Fixes a typo in an e2e test that causes it to fail -> https://github.com/SAP/ai-sdk-js/actions/runs/13445525274/job/37569879740
