### PR TITLE
chore: Remove node engine 20 in sample app

### DIFF
--- a/sample-code/package.json
+++ b/sample-code/package.json
@@ -11,9 +11,6 @@
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map"
   ],
-  "engines": {
-    "node": "^20"
-  },
   "scripts": {
     "start": "node --loader ts-node/esm src/server.ts",
     "local": "node --env-file=.env --loader ts-node/esm src/server.ts",

--- a/tests/smoke-tests/package.json
+++ b/tests/smoke-tests/package.json
@@ -14,9 +14,6 @@
     "lint": "eslint . && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -c",
     "lint:fix": "eslint . --fix && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --log-level error"
   },
-  "engines": {
-    "node": "^20"
-  },
   "dependencies": {
     "langchain": "0.3.19",
     "@langchain/core": "0.3.42",


### PR DESCRIPTION
## Context

I dont remember why we pinned the node engine to 20. But I keep getting warnings when using node 22 (which is what we officially support) that I'm using an incompatible version. I ran both [smoke](https://github.com/SAP/ai-sdk-js/actions/runs/13768082407) and [e2e test](https://github.com/SAP/ai-sdk-js/actions/runs/13768248283) on this branch and they both succeed. So I believe its fine to remove the engine. 

