### PR TITLE
chore: Remove deprecated models

### DIFF
--- a/.changeset/dark-flies-try.md
+++ b/.changeset/dark-flies-try.md
@@ -1,0 +1,7 @@
+---
+'@sap-ai-sdk/core': minor
+---
+
+[Compatibility Note] Removed deprecated model `text-embedding-ada-002`.
+
+Use suggested replacements `text-embedding-3-small` or `text-embedding-3-large` instead.

--- a/.changeset/dark-flies-try.md
+++ b/.changeset/dark-flies-try.md
@@ -3,5 +3,4 @@
 ---
 
 [Compatibility Note] Removed deprecated model `text-embedding-ada-002`.
-
-Use suggested replacements `text-embedding-3-small` or `text-embedding-3-large` instead.
+Use `text-embedding-3-small` or `text-embedding-3-large` instead.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Setup your SAP AI Core instance with SAP Cloud SDK for AI.
   - [@sap-ai-sdk/document-grounding](#sap-ai-sdkdocument-grounding)
   - [@sap-ai-sdk/prompt-registry](#sap-ai-sdkprompt-registry)
 - [SAP Cloud SDK for AI Sample Project](#sap-cloud-sdk-for-ai-sample-project)
+- [Deprecated Models](#deprecated-models)
 - [Error Handling](#error-handling)
   - [Accessing Error Information](#accessing-error-information)
 - [Local Testing](#local-testing)
@@ -123,6 +124,16 @@ For details on prompt registry client, refer to this [document](https://github.c
 
 We have created a sample project demonstrating the different clients' usage of the SAP Cloud SDK for AI for TypeScript/JavaScript.
 The [project README](https://github.com/SAP/ai-sdk-js/blob/main/sample-code/README.md) outlines the set-up needed to build and run it locally.
+
+## Deprecated Models
+
+The following models are deprecated and should not be used.
+Update your code to use one of the recommended replacement models.
+
+**text-embedding-ada-002**
+
+- Retirement Date: 2025-10-03
+- Replacement Models: `text-embedding-3-small` or `text-embedding-3-large`
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ The [project README](https://github.com/SAP/ai-sdk-js/blob/main/sample-code/READ
 The following models are deprecated and should not be used.
 Update your code to use one of the recommended replacement models.
 
-**text-embedding-ada-002**
+| Model Name               | Replacement                                        |
+|--------------------------|----------------------------------------------------|
+| `text-embedding-ada-002` | `text-embedding-3-small`, `text-embedding-3-large` |
 
-- Retirement Date: 2025-10-03
-- Replacement Models: `text-embedding-3-small` or `text-embedding-3-large`
+For more information, refer to the SAP note on [Availability of Generative AI Models](https://me.sap.com/notes/3437766).
 
 ## Error Handling
 

--- a/packages/core/src/model-types.ts
+++ b/packages/core/src/model-types.ts
@@ -18,7 +18,7 @@ export type AzureOpenAiChatModel = LiteralUnion<
  * Azure OpenAI models for embedding.
  */
 export type AzureOpenAiEmbeddingModel = LiteralUnion<
-  'text-embedding-ada-002' | 'text-embedding-3-small' | 'text-embedding-3-large'
+  'text-embedding-3-small' | 'text-embedding-3-large'
 >;
 
 /**

--- a/packages/document-grounding/README.md
+++ b/packages/document-grounding/README.md
@@ -92,7 +92,8 @@ const response: DocumentsListResponse = await VectorApi.createDocuments(
 ).execute();
 ```
 
-**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03. All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
+**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03. 
+All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
 
 ### Custom Destination
 

--- a/packages/document-grounding/README.md
+++ b/packages/document-grounding/README.md
@@ -92,9 +92,6 @@ const response: DocumentsListResponse = await VectorApi.createDocuments(
 ).execute();
 ```
 
-**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03.
-All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
-
 ### Custom Destination
 
 When calling the `execute()` method, it is possible to provide a custom destination.

--- a/packages/document-grounding/README.md
+++ b/packages/document-grounding/README.md
@@ -55,7 +55,7 @@ const response = await VectorApi.createCollection(
   {
     title: 'ai-sdk-js-e2e',
     embeddingConfig: {
-      modelName: 'text-embedding-ada-002'
+      modelName: 'text-embedding-3-small'
     },
     metadata: []
   },
@@ -91,6 +91,8 @@ const response: DocumentsListResponse = await VectorApi.createDocuments(
   }
 ).execute();
 ```
+
+**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03. All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
 
 ### Custom Destination
 

--- a/packages/document-grounding/src/tests/vector-api.test.ts
+++ b/packages/document-grounding/src/tests/vector-api.test.ts
@@ -23,7 +23,7 @@ describe('vector api', () => {
         {
           title: 'ai-sdk-js-demo',
           embeddingConfig: {
-            modelName: 'text-embedding-ada-002'
+            modelName: 'text-embedding-3-small'
           },
           metadata: [],
           id: '7171c2b2-835b-4745-8824-ff5c7e98a416'

--- a/packages/foundation-models/README.md
+++ b/packages/foundation-models/README.md
@@ -241,9 +241,6 @@ const response = await embeddingClient.run({
 const embedding = response.getEmbedding();
 ```
 
-**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03.
-All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
-
 ### Custom Request Configuration
 
 Set custom request configuration in the `requestConfig` parameter when calling the `run()` method of a chat or embedding client.

--- a/packages/foundation-models/README.md
+++ b/packages/foundation-models/README.md
@@ -241,7 +241,8 @@ const response = await embeddingClient.run({
 const embedding = response.getEmbedding();
 ```
 
-**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03. All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
+**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03. 
+All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
 
 ### Custom Request Configuration
 

--- a/packages/foundation-models/README.md
+++ b/packages/foundation-models/README.md
@@ -233,13 +233,15 @@ Use the `AzureOpenAiEmbeddingClient` to send embedding requests to an OpenAI mod
 import { AzureOpenAiEmbeddingClient } from '@sap-ai-sdk/foundation-models';
 
 const embeddingClient = new AzureOpenAiEmbeddingClient(
-  'text-embedding-ada-002'
+  'text-embedding-3-small'
 );
 const response = await embeddingClient.run({
   input: 'AI is fascinating'
 });
 const embedding = response.getEmbedding();
 ```
+
+**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03. All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
 
 ### Custom Request Configuration
 

--- a/packages/langchain/src/openai/README.md
+++ b/packages/langchain/src/openai/README.md
@@ -178,9 +178,6 @@ const vectorStore = await MemoryVectorStore.fromDocuments(
 const retriever = vectorStore.asRetriever();
 ```
 
-**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03.
-All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
-
 ## Local Testing
 
 For local testing instructions, refer to this [section](https://github.com/SAP/ai-sdk-js/blob/main/README.md#local-testing).

--- a/packages/langchain/src/openai/README.md
+++ b/packages/langchain/src/openai/README.md
@@ -165,7 +165,7 @@ const splits = await textSplitter.splitDocuments(docs);
 
 // Initialize the embedding client
 const embeddingClient = new AzureOpenAiEmbeddingClient({
-  modelName: 'text-embedding-ada-002'
+  modelName: 'text-embedding-3-small'
 });
 
 // Create a vector store from the document
@@ -177,6 +177,8 @@ const vectorStore = await MemoryVectorStore.fromDocuments(
 // Create a retriever for the vector store
 const retriever = vectorStore.asRetriever();
 ```
+
+**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03. All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
 
 ## Local Testing
 

--- a/packages/langchain/src/openai/README.md
+++ b/packages/langchain/src/openai/README.md
@@ -178,7 +178,8 @@ const vectorStore = await MemoryVectorStore.fromDocuments(
 const retriever = vectorStore.asRetriever();
 ```
 
-**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03. All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
+**Note:** Previous versions of this documentation referenced the `text-embedding-ada-002` model, which is now deprecated and scheduled for retirement on 2025-10-03. 
+All examples have been updated to use the recommended replacement models: `text-embedding-3-small` or `text-embedding-3-large`.
 
 ## Local Testing
 

--- a/sample-code/src/document-grounding.ts
+++ b/sample-code/src/document-grounding.ts
@@ -13,7 +13,7 @@ export async function createCollection(): Promise<string> {
     {
       title: 'ai-sdk-js-e2e',
       embeddingConfig: {
-        modelName: 'text-embedding-ada-002'
+        modelName: 'text-embedding-3-small'
       },
       metadata: []
     },

--- a/sample-code/src/foundation-models/azure-openai.ts
+++ b/sample-code/src/foundation-models/azure-openai.ts
@@ -60,7 +60,7 @@ export async function chatCompletionStream(
  */
 export async function computeEmbedding(): Promise<AzureOpenAiEmbeddingResponse> {
   const response = await new AzureOpenAiEmbeddingClient(
-    'text-embedding-ada-002'
+    'text-embedding-3-small'
   ).run({
     input: 'Hello, world!'
   });

--- a/sample-code/src/langchain-azure-openai.ts
+++ b/sample-code/src/langchain-azure-openai.ts
@@ -87,7 +87,7 @@ export async function invokeRagChain(): Promise<string> {
 
   // Initialize the embedding client with 0 retries for fast testing
   const embeddingClient = new AzureOpenAiEmbeddingClient({
-    modelName: 'text-embedding-ada-002',
+    modelName: 'text-embedding-3-small',
     maxRetries: 0
   });
 

--- a/tests/type-tests/test/azure-openai.test-d.ts
+++ b/tests/type-tests/test/azure-openai.test-d.ts
@@ -123,7 +123,7 @@ expectType<Promise<AzureOpenAiChatCompletionResponse>>(
  */
 
 expectType<Promise<AzureOpenAiEmbeddingResponse>>(
-  new AzureOpenAiEmbeddingClient('text-embedding-ada-002').run({
+  new AzureOpenAiEmbeddingClient('text-embedding-3-small').run({
     input: 'test input'
   })
 );
@@ -136,7 +136,7 @@ expectType<AzureOpenAiEmbeddingClient>(
  * Embeddings with optional parameters.
  */
 expectType<Promise<AzureOpenAiEmbeddingResponse>>(
-  new AzureOpenAiEmbeddingClient('text-embedding-ada-002').run(
+  new AzureOpenAiEmbeddingClient('text-embedding-3-small').run(
     {
       input: ['test input 1', 'test input 2'],
       user: 'some-guid'
@@ -150,7 +150,7 @@ expectType<Promise<AzureOpenAiEmbeddingResponse>>(
 );
 
 expectType<Promise<AzureOpenAiEmbeddingResponse>>(
-  new AzureOpenAiEmbeddingClient('text-embedding-ada-002', {
+  new AzureOpenAiEmbeddingClient('text-embedding-3-small', {
     destinationName: 'destinationName',
     useCache: false
   }).run({


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#257.

## What this PR does and why it is needed

Replaces `text-embedding-ada-002` in our sample-code and documentation with the suggested replacements according to [SAP notes](https://me.sap.com/notes/3437766).
