### PR TITLE
chore: Pin `vchrisb/setup-cf` version using full SHA

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: sap/ai-sdk-js/.github/actions/setup@main
       - run: pnpm smoke-tests create-deployment
-      - uses: vchrisb/setup-cf@v1
+      - uses: vchrisb/setup-cf@7e7a19573c9a2cf138f00399472dfc4e423d1f92
         with:
           api: ${{ vars.CF_API_URL }}
           username: ${{ secrets.CF_USER }}


### PR DESCRIPTION
## Context

Relates to SAP/ai-sdk-js-backlog#221.

## What this PR does and why it is needed

https://github.com/vchrisb/setup-cf/commit/7e7a19573c9a2cf138f00399472dfc4e423d1f92

Pin the version to `7e7a19573c9a2cf138f00399472dfc4e423d1f92` (release version v1.0.3).
