### PR TITLE
feat: Support setting `metadata_params` property in `buildDocumentGroundingConfig()` convenience function

### DIFF
--- a/.changeset/fast-showers-prove.md
+++ b/.changeset/fast-showers-prove.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/orchestration': minor
+---
+
+[New Functionality] Support setting `metadata_params` property in `buildDocumentGroundingConfig()` convenience function.

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -471,18 +471,18 @@ const orchestrationClient = new OrchestrationClient({
     ],
     defaults: {}
   },
-  grounding: buildDocumentGroundingConfig(
+  grounding: buildDocumentGroundingConfig({
     input_params: ['groundingRequest'],
     output_param: 'groundingOutput',
     // metadata_params: ['PARAM_NAME']
     filters: [
-        {
-          id: 'FILTER_ID',
-          // data_repository_type: 'vector', // optional, default value is 'vector'
-          data_repositories: ['REPOSITORY_ID'],
-        }
-      ],
-    )
+      {
+        id: 'FILTER_ID',
+        // data_repository_type: 'vector', // optional, default value is 'vector'
+        data_repositories: ['REPOSITORY_ID'],
+      }
+    ],
+  })
 });
 
 const response = await orchestrationClient.chatCompletion({

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -479,14 +479,16 @@ const orchestrationClient = new OrchestrationClient({
       {
         id: 'FILTER_ID',
         // data_repository_type: 'vector', // optional, default value is 'vector'
-        data_repositories: ['REPOSITORY_ID'],
+        data_repositories: ['REPOSITORY_ID']
       }
-    ],
+    ]
   })
 });
 
 const response = await orchestrationClient.chatCompletion({
-  inputParams: { groundingRequest: 'Give me a short introduction of SAP AI Core.' }
+  inputParams: {
+    groundingRequest: 'Give me a short introduction of SAP AI Core.'
+  }
 });
 return response.getContent();
 ```

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -496,7 +496,7 @@ return response.getContent();
 By default, the optional filter property `data_repository_type` is set to `vector`.
 Set it to `help.sap.com` to retrieve context from the SAP Help Portal.
 Set `metadata_params` property with an array of parameter names to include [metadata](https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/metadata) in the grounding result, which can be used in the prompt.
-Set `data_respotiories` property with an array of repository IDs to search in specific data repositories.
+Set `data_repositories` property with an array of repository IDs to search in specific data repositories.
 Skip this property to search in all available data repositories.
 
 ### Using a JSON Configuration from AI Launchpad

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -474,6 +474,7 @@ const orchestrationClient = new OrchestrationClient({
   grounding: buildDocumentGroundingConfig(
     input_params: ['groundingRequest'],
     output_param: 'groundingOutput',
+    // metadata_params: ['PARAM_NAME']
     filters: [
         {
           id: 'FILTER_ID',
@@ -492,7 +493,8 @@ return response.getContent();
 
 By default, the optional filter property `data_repository_type` is set to `vector`.
 Set it to `help.sap.com` to retrieve context from the SAP Help Portal.
-Set `data_respotiories` property with an array of `REPOSITORY_ID` values to search in specific data repositories.
+Set `metadata_params` property with an array of parameter names to include [metadata](https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/metadata) in the grounding result, which can be used in the prompt.
+Set `data_respotiories` property with an array of repository IDs to search in specific data repositories.
 Skip this property to search in all available data repositories.
 
 ### Using a JSON Configuration from AI Launchpad

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -164,6 +164,10 @@ export interface DocumentGroundingServiceConfig {
    * @example "groundingOutput"
    */
   output_param: string;
+  /**
+   * Parameter name used for specifying metadata parameters.
+   */
+  metadata_params?: string[];
 }
 
 /**

--- a/packages/orchestration/src/util/grounding.test.ts
+++ b/packages/orchestration/src/util/grounding.test.ts
@@ -2,11 +2,12 @@ import { buildDocumentGroundingConfig } from './grounding.js';
 import type { DocumentGroundingServiceConfig } from '../orchestration-types.js';
 
 describe('document grounding util', () => {
-  it('builds grounding configuration with minimal required properties', () => {
+  it('builds simple grounding configuration', () => {
     const groundingConfig: DocumentGroundingServiceConfig = {
       filters: [{}],
       input_params: ['input'],
-      output_param: 'output'
+      output_param: 'output',
+      metadata_params: ['param1', 'param2']
     };
     expect(buildDocumentGroundingConfig(groundingConfig)).toEqual({
       type: 'document_grounding_service',
@@ -17,7 +18,8 @@ describe('document grounding util', () => {
           }
         ],
         input_params: ['input'],
-        output_param: 'output'
+        output_param: 'output',
+        metadata_params: ['param1', 'param2']
       }
     });
   });

--- a/packages/orchestration/src/util/grounding.ts
+++ b/packages/orchestration/src/util/grounding.ts
@@ -19,6 +19,9 @@ export function buildDocumentGroundingConfig(
           data_repository_type: 'vector',
           ...filter
         }))
+      }),
+      ...(groundingConfig.metadata_params && {
+        metadata_params: groundingConfig.metadata_params
       })
     }
   };

--- a/sample-code/src/document-grounding.ts
+++ b/sample-code/src/document-grounding.ts
@@ -57,7 +57,12 @@ export async function createDocumentsWithTimestamp(
           chunks: [
             {
               content: `The last SAP AI SDK JavaScript end to end test was run at ${timestamp}.`,
-              metadata: []
+              metadata: [
+                {
+                  key: 'context',
+                  value: ['sap-ai-sdk-js']
+                }
+              ]
             }
           ]
         }

--- a/sample-code/src/orchestration.ts
+++ b/sample-code/src/orchestration.ts
@@ -397,7 +397,8 @@ export async function orchestrationGroundingVector(): Promise<OrchestrationRespo
       grounding: buildDocumentGroundingConfig({
         input_params: ['groundingRequest'],
         output_param: 'groundingOutput',
-        filters: [{ data_repository_type: 'vector' }]
+        filters: [{ data_repository_type: 'vector' }],
+        metadata_params: ['context']
       })
     },
     { resourceGroup: 'ai-sdk-js-e2e' }

--- a/sample-code/src/server.ts
+++ b/sample-code/src/server.ts
@@ -462,7 +462,8 @@ app.get(
       );
 
       // Print the grounding data.
-      const groundingResultString = groundingResult.data.module_results.grounding?.data?.grounding_result;
+      const groundingResultString =
+        groundingResult.data.module_results.grounding?.data?.grounding_result;
       res.write(
         `Orchestration grounding metadata:\t${JSON.stringify(JSON.parse(groundingResultString)[0].metadata)}\n`
       );

--- a/sample-code/src/server.ts
+++ b/sample-code/src/server.ts
@@ -461,6 +461,12 @@ app.get(
         `Orchestration responded with timestamp:\t${groundingResult.getContent()}\n`
       );
 
+      // Print the grounding data.
+      const groundingResultString = groundingResult.data.module_results.grounding?.data?.grounding_result;
+      res.write(
+        `Orchestration grounding metadata:\t${JSON.stringify(JSON.parse(groundingResultString)[0].metadata)}\n`
+      );
+
       // Delete the created collection.
       await deleteCollection(collectionId);
       res.write(`Collection deleted:\t\t\t${collectionId}\n`);


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#267.

## What this PR does and why it is needed

`buildDocumentGroundingConfig()` now support `metadata_params` as an optional parameter. When defining this property, the grounding result will include metadata as part of the JSON string.

Sample result for grounding module:

```json
{
  "message": "grounding result",
  "data": {
    "grounding_query": "grounding call",
    "grounding_result": "[{\"content\": \"The last SAP AI SDK JavaScript end to end test was run at 1743431349413.\", \"metadata\": {\"context\": [\"sap-ai-sdk-js\"]}}]"
  }
}
```

Since `metadata` is now part of the `grounding_result` it can be used / mentioned in the prompt.