### PR TITLE
chore: Add type for `templating` in sample code

### DIFF
--- a/sample-code/src/orchestration.ts
+++ b/sample-code/src/orchestration.ts
@@ -166,7 +166,9 @@ export async function orchestrationPromptRegistry(): Promise<OrchestrationRespon
   });
 }
 
-const templating: TemplatingModuleConfig = { template: [{ role: 'user', content: '{{?input}}' }] };
+const templating: TemplatingModuleConfig = {
+  template: [{ role: 'user', content: '{{?input}}' }]
+};
 
 /**
  * Apply multiple content filters to the input.

--- a/sample-code/src/orchestration.ts
+++ b/sample-code/src/orchestration.ts
@@ -17,7 +17,8 @@ import type {
   OrchestrationStreamResponse,
   OrchestrationResponse,
   StreamOptions,
-  ErrorResponse
+  ErrorResponse,
+  TemplatingModuleConfig
 } from '@sap-ai-sdk/orchestration';
 
 const logger = createLogger({
@@ -165,7 +166,7 @@ export async function orchestrationPromptRegistry(): Promise<OrchestrationRespon
   });
 }
 
-const templating = { template: [{ role: 'user', content: '{{?input}}' }] };
+const templating: TemplatingModuleConfig = { template: [{ role: 'user', content: '{{?input}}' }] };
 
 /**
  * Apply multiple content filters to the input.


### PR DESCRIPTION
`templating` was not typed. Will cause issue later when migrating to a new orchestration spec.