### PR TITLE
chore: Add cron job for spec update

### DIFF
--- a/.github/workflows/spec-update-cron.yaml
+++ b/.github/workflows/spec-update-cron.yaml
@@ -1,0 +1,24 @@
+name: "Spec File Update Workflow (Cron Job)"
+
+on:
+  schedule:
+    - cron: 21 3 */15 * * # At 03:21 on every 15th day-of-month.
+  workflow_dispatch: # TODO: remove this once tested
+
+jobs:
+  spec-update-ai-api:
+    uses: SAP/ai-sdk-js/.github/workflows/spec-update.yaml@create-bi-weekly-schedule-for-spec-updates # TODO: change back to main
+    with:
+      file: ai-api
+  spec-update-document-grounding:
+    uses: SAP/ai-sdk-js/.github/workflows/spec-update.yaml@create-bi-weekly-schedule-for-spec-updates
+    with:
+      file: document-grounding
+  spec-update-orchestration:
+    uses: SAP/ai-sdk-js/.github/workflows/spec-update.yaml@create-bi-weekly-schedule-for-spec-updates
+    with:
+      file: orchestration
+  spec-update-prompt-registry:
+    uses: SAP/ai-sdk-js/.github/workflows/spec-update.yaml@create-bi-weekly-schedule-for-spec-updates
+    with:
+      file: prompt-registry

--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -23,6 +23,22 @@ on:
         required: false
         default: true
         type: boolean
+  workflow_call:
+    inputs:
+      file:
+        description: "Which spec file to update"
+        required: true
+        type: string
+      file-ref:
+        description: "Branch or tag to checkout the spec file from"
+        required: false
+        default: main
+        type: string
+      create-pr:
+        description: "Create a pull request after updating the spec file"
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   generate:


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#277.

## What this PR does and why it is needed

Update specs biweekly with schedule for

- ai-api
- document-grounding
- orchestration
- prompt-registry
