### PR TITLE
fix: OpenAI streaming if finish reason is null

### DIFF
--- a/.changeset/big-breads-show.md
+++ b/.changeset/big-breads-show.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/foundation-models': patch
+---
+
+[Fixed Issue] Remove incorrect error logging if finish reason is null in the streaming chunk.

--- a/packages/foundation-models/src/azure-openai/azure-openai-chat-completion-stream.test.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-chat-completion-stream.test.ts
@@ -54,6 +54,7 @@ describe('OpenAI chat completion stream', () => {
       messageContext: 'azure-openai-chat-completion-stream'
     });
     const debugSpy = jest.spyOn(logger, 'debug');
+    const errorSpy = jest.spyOn(logger, 'error');
     const asyncGeneratorChunk = AzureOpenAiChatCompletionStream._processChunk(
       originalChatCompletionStream
     );
@@ -69,6 +70,7 @@ describe('OpenAI chat completion stream', () => {
       expect(chunk).toBeDefined();
     }
     expect(debugSpy).toHaveBeenCalledWith('Choice 0: Stream finished.');
+    expect(errorSpy).toHaveBeenCalledTimes(0);
   });
 
   it('should process the token usage', async () => {

--- a/packages/foundation-models/src/azure-openai/azure-openai-chat-completion-stream.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-chat-completion-stream.ts
@@ -57,7 +57,7 @@ export class AzureOpenAiChatCompletionStream<Item> extends SseStream<Item> {
         const choiceIndex = choice.index;
         if (choiceIndex >= 0) {
           const finishReason = chunk.getFinishReason(choiceIndex);
-          if (finishReason !== undefined) {
+          if (finishReason) {
             if (response) {
               response._getFinishReasons().set(choiceIndex, finishReason);
             }


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

## What this PR does and why it is needed

A bug reported [here](https://github.com/SAP/ai-sdk-js/issues/670). `finishReason` is nullable.
