### PR TITLE
fix: Delete existing origin branch when running spec update workflow

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -70,6 +70,8 @@ jobs:
           BRANCH="spec-update/$CHOICE/$REF"
           git fetch origin $BRANCH || true
           git checkout -B $BRANCH origin/$BRANCH || git checkout -b $BRANCH
+          git rebase main
+          git push --force
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: "Download specification file"

--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -191,6 +191,10 @@ jobs:
         run: |
           DIFF_URL="https://github.com/SAP/ai-sdk-js/compare/main...$BRANCH"
           echo "## Workflow Execution Summary" >> $GITHUB_STEP_SUMMARY
+
+          echo "**Choice:** $CHOICE" >> $GITHUB_STEP_SUMMARY
+          echo "**Ref:** $REF" >> $GITHUB_STEP_SUMMARY
+
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -71,7 +71,7 @@ jobs:
           git fetch origin $BRANCH || true
           git checkout -B $BRANCH origin/$BRANCH || git checkout -b $BRANCH
           git rebase main
-          git push --force
+          git push
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: "Download specification file"


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#305.

## What this PR does and why it is needed

The spec update creates spec/update/... branches. However, we never delete them if no PR is needed. Then the next time, we checkout those branches from remote origin, which is probably behind of main. This causes issue like in http://github.com/SAP/ai-sdk-js/pull/693

In this PR we rebase the current main when checking out the existing branch. In principal, there should be no rebase conflicts as developers should not change the generated files or making diverged changes to the spec file. And no one should ever check out a spec branch and push changes manually, so no need to force push.
