### PR TITLE
chore: Update add-changelog.ts

### DIFF
--- a/scripts/add-changelog.ts
+++ b/scripts/add-changelog.ts
@@ -17,7 +17,7 @@ async function getChangelogWithVersion(v?: string): Promise<string> {
   const month = date.toLocaleString('default', { month: 'long' });
   const year = date.getFullYear();
 
-  const headerWithVersion = `\n## ${v} [Core Modules] - ${month} ${day}, ${year}`;
+  const headerWithVersion = `\n## ${v} - ${month} ${day}, ${year}`;
 
   return [headerWithVersion, logs].join('\n');
 }


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

## What this PR does and why it is needed

We don't have `[Core Modules]` in the ai-sdk release notes, different from cloud sdk. Thus, removing it.
