### PR TITLE
chore: Add changeset

### DIFF
--- a/.changeset/dark-geese-laugh.md
+++ b/.changeset/dark-geese-laugh.md
@@ -1,0 +1,6 @@
+---
+'@sap-ai-sdk/document-grounding': patch
+'@sap-ai-sdk/orchestration': patch
+---
+
+[New Functionality] Add support for S3-based document grounding.


### PR DESCRIPTION
## What this PR does and why it is needed

Adds a changeset for the support of S3-based document grounding.
