### PR TITLE
feat: Support LangChain Azure OpenAI `bindTools()` method

### DIFF
--- a/.changeset/empty-corners-ask.md
+++ b/.changeset/empty-corners-ask.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/langchain': minor
+---
+
+[New Feature] Support `bindTools()` method in Azure OpenAI LangChain client.

--- a/packages/langchain/src/openai/types.ts
+++ b/packages/langchain/src/openai/types.ts
@@ -8,7 +8,8 @@ import type {
   AzureOpenAiCreateChatCompletionRequest,
   AzureOpenAiChatModel,
   AzureOpenAiEmbeddingModel,
-  AzureOpenAiChatCompletionsRequestCommon
+  AzureOpenAiChatCompletionsRequestCommon,
+  AzureOpenAiChatCompletionTool
 } from '@sap-ai-sdk/foundation-models';
 import type { CustomRequestConfig } from '@sap-ai-sdk/core';
 import type { ModelConfig, ResourceGroupConfig } from '@sap-ai-sdk/ai-api';
@@ -32,10 +33,16 @@ export type AzureOpenAiChatModelParams = Pick<
    * If `undefined` the `strict` argument will not be passed to OpenAI.
    */
   supportsStrictToolCalling?: boolean;
-} &
-  BaseChatModelParams &
+} & BaseChatModelParams &
   ModelConfig<AzureOpenAiChatModel> &
   ResourceGroupConfig;
+
+/**
+ * Tool type for Azure OpenAI.
+ */
+export type ChatAzureOpenAIToolType =
+  | AzureOpenAiChatCompletionTool
+  | BindToolsInput;
 
 /**
  * Call options for the {@link AzureOpenAiChatClient}.
@@ -54,7 +61,7 @@ export type AzureOpenAiChatCallOptions = BaseChatModelCallOptions &
     | 'function_call'
   > & {
     strict?: boolean;
-    tools?: BindToolsInput[];
+    tools?: ChatAzureOpenAIToolType[];
     requestConfig?: CustomRequestConfig;
   };
 

--- a/packages/langchain/src/openai/types.ts
+++ b/packages/langchain/src/openai/types.ts
@@ -25,7 +25,13 @@ export type AzureOpenAiChatModelParams = Pick<
   | 'frequency_penalty'
   | 'logit_bias'
   | 'user'
-> &
+> & {
+  /**
+   * Whether the model supports the `strict` argument when passing in tools.
+   * If `undefined` the `strict` argument will not be passed to OpenAI.
+   */
+  supportsStrictToolCalling?: boolean;
+} &
   BaseChatModelParams &
   ModelConfig<AzureOpenAiChatModel> &
   ResourceGroupConfig;
@@ -47,6 +53,7 @@ export type AzureOpenAiChatCallOptions = BaseChatModelCallOptions &
     | 'function_call'
     | 'tools'
   > & {
+    strict?: boolean;
     requestConfig?: CustomRequestConfig;
   };
 

--- a/sample-code/src/langchain-azure-openai.ts
+++ b/sample-code/src/langchain-azure-openai.ts
@@ -163,15 +163,13 @@ export async function invokeToolChain(): Promise<string> {
     })
   });
 
-  const humanMessage = new HumanMessage(
-    'Increase the shareholder value, it is currently at 10'
-  );
+  const messages: BaseMessage[] = [
+    new HumanMessage('Increase the shareholder value, it is currently at 10')
+  ];
 
-  const history: BaseMessage[] = [humanMessage];
+  const response = await client.bindTools([azureTool]).invoke(messages);
 
-  const response = await client.invoke(history, { tools: [azureTool] });
-
-  history.push(response);
+  messages.push(response);
 
   if (response.tool_calls) {
     const shareholderValue = shareholderValueFunction(
@@ -183,13 +181,13 @@ export async function invokeToolChain(): Promise<string> {
       tool_call_id: response.tool_calls[0].id ?? 'default'
     });
 
-    history.push(toolMessage);
+    messages.push(toolMessage);
   } else {
     const failMessage = new SystemMessage('No tool calls were made');
-    history.push(failMessage);
+    messages.push(failMessage);
   }
 
-  const finalResponse = await client.invoke(history);
+  const finalResponse = await client.invoke(messages);
 
   // create an output parser
   const parser = new StringOutputParser();


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#308.

## What this PR does and why it is needed

Before, user scan only pass tools when calling `invoke()`.

```ts
const response = await client.invoke(messages, { tools: [azureTool] });
```

Now, they can bind tools to a client before calling the invoke method.

```ts
const myTool = tool(...);
const modelWithTools = client.bindTools([myTool]);
```

Both `bindTools()` and `invoke()` support the following tool types:

1. Tools created with `tool()` function from LangChain
2. Structured tool `{ name: string, description: string, schema: ZodSchema | JSONSchema }`
3. Azure tool / function definition `{ type: 'function', function: { name: string, description: string, parameters: JSONSchema } }`

