### PR TITLE
chore: Fix types and checks for TemplatingModuleConfig

### DIFF
--- a/packages/langchain/src/orchestration/client.ts
+++ b/packages/langchain/src/orchestration/client.ts
@@ -120,7 +120,7 @@ export class OrchestrationClient extends BaseChatModel<
     options: typeof this.ParsedCallOptions
   ): LangchainOrchestrationModuleConfig {
     const { tools = [], stop = [] } = options;
-    let config: LangchainOrchestrationModuleConfig =  {
+    const config: LangchainOrchestrationModuleConfig = {
       ...this.orchestrationConfig,
       llm: {
         ...this.orchestrationConfig.llm,
@@ -135,13 +135,10 @@ export class OrchestrationClient extends BaseChatModel<
         }
       }
     };
-      config.templating = this.orchestrationConfig.templating;
-      if (config.templating && isTemplate(config.templating) && tools.length) {
-        config.templating.tools = [
-            ...(config.templating.tools || []),
-            ...tools
-          ]
-        }
-        return config;
-      }
+    config.templating = this.orchestrationConfig.templating;
+    if (config.templating && isTemplate(config.templating) && tools.length) {
+      config.templating.tools = [...(config.templating.tools || []), ...tools];
+    }
+    return config;
   }
+}

--- a/packages/langchain/src/orchestration/client.ts
+++ b/packages/langchain/src/orchestration/client.ts
@@ -120,7 +120,7 @@ export class OrchestrationClient extends BaseChatModel<
     options: typeof this.ParsedCallOptions
   ): LangchainOrchestrationModuleConfig {
     const { tools = [], stop = [] } = options;
-    return {
+    let config: LangchainOrchestrationModuleConfig =  {
       ...this.orchestrationConfig,
       llm: {
         ...this.orchestrationConfig.llm,
@@ -133,18 +133,15 @@ export class OrchestrationClient extends BaseChatModel<
             ]
           })
         }
-      },
-      templating: {
-        ...this.orchestrationConfig.templating,
-        ...(this.orchestrationConfig.templating &&
-          isTemplate(this.orchestrationConfig.templating) &&
-          tools.length && {
-            tools: [
-              ...(this.orchestrationConfig.templating.tools || []),
-              ...tools
-            ]
-          })
       }
     };
+      config.templating = this.orchestrationConfig.templating;
+      if (config.templating && isTemplate(config.templating) && tools.length) {
+        config.templating.tools = [
+            ...(config.templating.tools || []),
+            ...tools
+          ]
+        }
+        return config;
+      }
   }
-}

--- a/packages/langchain/src/orchestration/util.ts
+++ b/packages/langchain/src/orchestration/util.ts
@@ -3,7 +3,8 @@ import type { ChatResult } from '@langchain/core/outputs';
 import type {
   ChatMessage,
   CompletionPostResponse,
-  Template
+  Template,
+  TemplatingModuleConfig
 } from '@sap-ai-sdk/orchestration';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { AzureOpenAiChatCompletionMessageToolCalls } from '@sap-ai-sdk/foundation-models';
@@ -19,7 +20,7 @@ import type {
  * @returns True if the object is a {@link Template}.
  * @internal
  */
-export function isTemplate(object: Record<string, any>): object is Template {
+export function isTemplate(object: TemplatingModuleConfig): object is Template {
   return 'template' in object;
 }
 

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -1,3 +1,4 @@
+import type { Xor } from '@sap-cloud-sdk/util';
 import type { CustomRequestConfig } from '@sap-cloud-sdk/http-client';
 import type { ChatModel } from './model-types.js';
 import type {
@@ -99,8 +100,9 @@ export type Template = Omit<OriginalTemplate, 'template'> & {
 
 /**
  * Representation of the 'TemplatingModuleConfig' schema.
+ * The type can be either a `Template` or a `TemplateRef`.
  */
-export type TemplatingModuleConfig = Template | TemplateRef;
+export type TemplatingModuleConfig = Xor<Template, TemplateRef>;
 
 /**
  * Orchestration module configuration.

--- a/packages/orchestration/src/util/module-config.ts
+++ b/packages/orchestration/src/util/module-config.ts
@@ -200,6 +200,8 @@ function isTemplate(
   templating: TemplatingModuleConfig
 ): templating is Template {
   return (
-    templating && typeof templating === 'object' && 'template' in templating
+    templating &&
+    typeof templating === 'object' &&
+    !('template_ref' in templating)
   );
 }

--- a/packages/orchestration/src/util/module-config.ts
+++ b/packages/orchestration/src/util/module-config.ts
@@ -134,7 +134,7 @@ export function constructCompletionPostRequest(
   streamOptions?: StreamOptions
 ): CompletionPostRequest {
   // Templating is not a string here as it is already parsed in `parseAndMergeTemplating` method
-  const templatingConfig = config.templating as TemplatingModuleConfig;
+  const templatingConfig = {...config.templating as TemplatingModuleConfig};
 
   if (isTemplate(templatingConfig)) {
     if (!templatingConfig.template?.length && !prompt?.messages?.length) {

--- a/packages/orchestration/src/util/module-config.ts
+++ b/packages/orchestration/src/util/module-config.ts
@@ -137,12 +137,12 @@ export function constructCompletionPostRequest(
   const templatingConfig = config.templating as TemplatingModuleConfig;
 
   if (isTemplate(templatingConfig)) {
-    if (!templatingConfig.template.length && !prompt?.messages?.length) {
+    if (!templatingConfig.template?.length && !prompt?.messages?.length) {
       throw new Error('Either a prompt template or messages must be defined.');
     }
     if (prompt?.messages?.length) {
       templatingConfig.template = [
-        ...templatingConfig.template,
+        ...(templatingConfig.template || []),
         ...prompt.messages
       ];
     }

--- a/packages/orchestration/src/util/module-config.ts
+++ b/packages/orchestration/src/util/module-config.ts
@@ -134,7 +134,7 @@ export function constructCompletionPostRequest(
   streamOptions?: StreamOptions
 ): CompletionPostRequest {
   // Templating is not a string here as it is already parsed in `parseAndMergeTemplating` method
-  const templatingConfig = {...config.templating as TemplatingModuleConfig};
+  const templatingConfig = { ...(config.templating as TemplatingModuleConfig) };
 
   if (isTemplate(templatingConfig)) {
     if (!templatingConfig.template?.length && !prompt?.messages?.length) {

--- a/tests/type-tests/test/orchestration.test-d.ts
+++ b/tests/type-tests/test/orchestration.test-d.ts
@@ -254,6 +254,18 @@ expectError<any>(new OrchestrationClient({}).chatCompletion());
 expectError<any>(
   new OrchestrationClient({
     templating: {
+      template: [{ role: 'user', content: 'Hello!' }],
+      template_ref: { id: 'template_id' }
+    },
+    llm: {
+      model_name: 'gpt-4o'
+    },
+  }).chatCompletion()
+);
+
+expectError<any>(
+  new OrchestrationClient({
+    templating: {
       template: [{ role: 'user', content: 'Hello!' }]
     },
     llm: {

--- a/tests/type-tests/test/orchestration.test-d.ts
+++ b/tests/type-tests/test/orchestration.test-d.ts
@@ -259,7 +259,7 @@ expectError<any>(
     },
     llm: {
       model_name: 'gpt-4o'
-    },
+    }
   }).chatCompletion()
 );
 


### PR DESCRIPTION
## Context

This PR fixes some issues identified in the failing e2e test:

- Tightened types of `TemplatingModuleConfig` to `Xor<Template, Template_Ref>` so user gets an error when they set both `template` and `template_ref`
- Not doing a shallow copy of the instance property config when concatenating `messages`
- Improving the TypeGuard to check for `template_ref`
