### PR TITLE
chore: Add latest embedding models

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,8 @@ export type {
   AzureOpenAiEmbeddingModel,
   GcpVertexAiChatModel,
   AwsBedrockChatModel,
-  AiCoreOpenSourceChatModel
+  AiCoreOpenSourceChatModel,
+  AwsBedrockEmbeddingModel,
+  NvidiaEmbeddingModel
 } from './model-types.js';
 export { SseStream, LineDecoder, SSEDecoder } from './stream/index.js';

--- a/packages/core/src/model-types.ts
+++ b/packages/core/src/model-types.ts
@@ -50,6 +50,13 @@ export type AwsBedrockChatModel = LiteralUnion<
 >;
 
 /**
+ * AWS Bedrock models for embedding.
+ */
+export type AwsBedrockEmbeddingModel = LiteralUnion<
+  'amazon--titan-embed-text'
+>;
+
+/**
  * AI Core open source models for chat completion.
  */
 export type AiCoreOpenSourceChatModel = LiteralUnion<
@@ -60,4 +67,11 @@ export type AiCoreOpenSourceChatModel = LiteralUnion<
   | 'ibm--granite-13b-chat'
   | 'alephalpha-pharia-1-7b-control'
   | 'deepseek-ai--deepseek-r1'
+>;
+
+/**
+ * Nvidia models for chat completion.
+ */
+export type NvidiaEmbeddingModel = LiteralUnion<
+  'nvidia--llama-3.2-nv-embedqa-1b'
 >;


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#331.

## What this PR does and why it is needed

With this PR, we add the latest embedding models that are available for the orchestration service.