### PR TITLE
chore: Add post-processing

### DIFF
--- a/packages/orchestration/src/orchestration-client.ts
+++ b/packages/orchestration/src/orchestration-client.ts
@@ -141,8 +141,8 @@ export class OrchestrationClient {
     });
 
     // Runs postProcessing of the response after the stream has been fully consumed.
-    // eslint-disable-next-line
     function postProcessing(
+      // eslint-disable-next-line
       response: OrchestrationStreamResponse<OrchestrationStreamChunkResponse>
     ): void {}
 


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#352.

## What this PR does and why it is needed

With this PR, we add the ability to add postprocessing after a stream closes.
This makes it easier for our utility functions to execute their logic that depends on chunks, e.g.:
- getToolCalls currently runs the entire mapping logic every single time instead of once after the stream
- getModuleResults (WIP) needs to merge the aggregated chunks at the end
- streamLock (WIP) needs to open the stream for the client again after the stream ends

Any other functionality we might want to add that depends on the closure of the stream also can be placed in this function.