### PR TITLE
chore: Add postprocessing to tool calls

### DIFF
--- a/packages/orchestration/src/orchestration-stream-response.ts
+++ b/packages/orchestration/src/orchestration-stream-response.ts
@@ -1,4 +1,3 @@
-import { isMessageToolCall } from './util/index.js';
 import type { ToolCallAccumulator } from './util/index.js';
 import type {
   MessageToolCalls,
@@ -20,6 +19,7 @@ export class OrchestrationStreamResponse<T> {
     Map<number, ToolCallAccumulator>
   > = new Map();
   private _stream: OrchestrationStream<T> | undefined;
+  private _toolCalls: Map<number, MessageToolCalls> = new Map();
 
   /**
    * Gets the token usage for the response.
@@ -65,26 +65,11 @@ export class OrchestrationStreamResponse<T> {
    * @returns The tool calls for the specified choice index.
    */
   public getToolCalls(choiceIndex = 0): MessageToolCalls | undefined {
-    try {
-      const toolCallsAccumulators =
-        this._toolCallsAccumulators.get(choiceIndex);
-      if (!toolCallsAccumulators) {
-        return undefined;
-      }
-      const toolCalls: MessageToolCalls = [];
-      for (const [id, acc] of toolCallsAccumulators.entries()) {
-        if (isMessageToolCall(acc)) {
-          toolCalls.push(acc);
-        } else {
-          throw new Error(`Tool call with id ${id} was incomplete.`);
-        }
-      }
-      return toolCalls;
-    } catch (error) {
-      throw new Error(
-        `Error while getting tool calls for choice index ${choiceIndex}: ${error}`
-      );
-    }
+    return this._toolCalls.get(choiceIndex);
+  }
+
+  _setToolCalls(choiceIndex: number, toolCalls: MessageToolCalls): void {
+    this._toolCalls.set(choiceIndex, toolCalls);
   }
 
   /**

--- a/packages/orchestration/src/orchestration-stream-response.ts
+++ b/packages/orchestration/src/orchestration-stream-response.ts
@@ -68,6 +68,9 @@ export class OrchestrationStreamResponse<T> {
     return this._toolCalls.get(choiceIndex);
   }
 
+  /**
+   * @internal
+   */
   _setToolCalls(choiceIndex: number, toolCalls: MessageToolCalls): void {
     this._toolCalls.set(choiceIndex, toolCalls);
   }

--- a/packages/orchestration/src/orchestration-stream.ts
+++ b/packages/orchestration/src/orchestration-stream.ts
@@ -1,8 +1,15 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { SseStream } from '@sap-ai-sdk/core';
 import { OrchestrationStreamChunkResponse } from './orchestration-stream-chunk-response.js';
-import { mergeToolCallChunk, type ToolCallAccumulator } from './internal.js';
-import type { CompletionPostResponseStreaming } from './client/api/schema/index.js';
+import {
+  isMessageToolCall,
+  mergeToolCallChunk,
+  type ToolCallAccumulator
+} from './internal.js';
+import type {
+  CompletionPostResponseStreaming,
+  MessageToolCalls
+} from './client/api/schema/index.js';
 import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 import type { OrchestrationStreamResponse } from './orchestration-stream-response.js';
 
@@ -81,6 +88,27 @@ export class OrchestrationStream<Item> extends SseStream<Item> {
         }
       });
       yield chunk;
+    }
+
+    for (const [
+      choiceIndex,
+      toolCallsAccumulators
+    ] of response._getToolCallsAccumulators()) {
+      const toolCalls: MessageToolCalls = [];
+      for (const [id, acc] of toolCallsAccumulators.entries()) {
+        try {
+          if (isMessageToolCall(acc)) {
+            toolCalls.push(acc);
+          } else {
+            throw new Error(`Tool call with id ${id} was incomplete.`);
+          }
+        } catch (error) {
+          logger.warn(
+            `Error while parsing tool calls for choice index ${choiceIndex}: ${error}`
+          );
+        }
+      }
+      response._setToolCalls(choiceIndex, toolCalls);
     }
   }
 

--- a/packages/orchestration/src/orchestration-stream.ts
+++ b/packages/orchestration/src/orchestration-stream.ts
@@ -96,15 +96,11 @@ export class OrchestrationStream<Item> extends SseStream<Item> {
     ] of response._getToolCallsAccumulators()) {
       const toolCalls: MessageToolCalls = [];
       for (const [id, acc] of toolCallsAccumulators.entries()) {
-        try {
-          if (isMessageToolCall(acc)) {
-            toolCalls.push(acc);
-          } else {
-            throw new Error(`Tool call with id ${id} was incomplete.`);
-          }
-        } catch (error) {
-          logger.warn(
-            `Error while parsing tool calls for choice index ${choiceIndex}: ${error}`
+        if (isMessageToolCall(acc)) {
+          toolCalls.push(acc);
+        } else {
+          logger.error(
+            `Error while parsing tool calls for choice index ${choiceIndex}: Tool call with id ${id} was incomplete.`
           );
         }
       }


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#352.

## What this PR does and why it is needed

With this PR, I move the post-processing into the stream, this way the tool calls are only computed once, and issues with any of them are visible immediately instead of after calling the respective function.

Relates to:
- #840 
