### PR TITLE
chore: Use correct type cast in `findChoiceByIndex()`

### DIFF
--- a/packages/orchestration/src/orchestration-response.ts
+++ b/packages/orchestration/src/orchestration-response.ts
@@ -5,7 +5,8 @@ import type {
   ChatMessage,
   ChatMessages,
   AssistantChatMessage,
-  MessageToolCalls
+  MessageToolCalls,
+  LlmChoice
 } from './client/api/schema/index.js';
 
 /**
@@ -100,10 +101,7 @@ export class OrchestrationResponse {
   }
 
   private findChoiceByIndex(index: number) {
-    // TODO: replace cast with LLMChoice[] after the bug in orchestration, where
-    // 'role' in ResponseChatMessage is optional when it should be mandatory, is fixed.
-    // https://github.com/SAP/ai-sdk-js-backlog/issues/306
-    return (this.getChoices() as any).find(
+    return (this.getChoices() as LlmChoice[]).find(
       (c: { index: number }) => c.index === index
     );
   }

--- a/packages/orchestration/src/orchestration-response.ts
+++ b/packages/orchestration/src/orchestration-response.ts
@@ -96,11 +96,16 @@ export class OrchestrationResponse {
     return this.findChoiceByIndex(choiceIndex)?.message;
   }
 
-  private getChoices(): LlmChoice[] {
-    return this.data.orchestration_result.choices;
+  /**
+   * Finds a specific choice from LLM module results.
+   * @param index - The index of the choice to find.
+   * @returns The LLM choice object.
+   */
+  findChoiceByIndex(index: number): LlmChoice | undefined {
+    return this.getChoices().find((c: { index: number }) => c.index === index);
   }
 
-  private findChoiceByIndex(index: number): LlmChoice | undefined {
-    return this.getChoices().find((c: { index: number }) => c.index === index);
+  private getChoices(): LlmChoice[] {
+    return this.data.orchestration_result.choices;
   }
 }

--- a/packages/orchestration/src/orchestration-response.ts
+++ b/packages/orchestration/src/orchestration-response.ts
@@ -97,9 +97,9 @@ export class OrchestrationResponse {
   }
 
   /**
-   * Finds a specific choice from LLM module results.
+   * Parses the response and returns the choice by index.
    * @param index - The index of the choice to find.
-   * @returns The LLM choice object.
+   * @returns An {@link LLMChoice} object associated with the index.
    */
   findChoiceByIndex(index: number): LlmChoice | undefined {
     return this.getChoices().find((c: { index: number }) => c.index === index);

--- a/packages/orchestration/src/orchestration-response.ts
+++ b/packages/orchestration/src/orchestration-response.ts
@@ -96,13 +96,11 @@ export class OrchestrationResponse {
     return this.findChoiceByIndex(choiceIndex)?.message;
   }
 
-  private getChoices() {
+  private getChoices(): LlmChoice[] {
     return this.data.orchestration_result.choices;
   }
 
-  private findChoiceByIndex(index: number) {
-    return (this.getChoices() as LlmChoice[]).find(
-      (c: { index: number }) => c.index === index
-    );
+  private findChoiceByIndex(index: number): LlmChoice | undefined {
+    return this.getChoices().find((c: { index: number }) => c.index === index);
   }
 }

--- a/packages/orchestration/src/orchestration-stream-chunk-response.ts
+++ b/packages/orchestration/src/orchestration-stream-chunk-response.ts
@@ -51,7 +51,7 @@ export class OrchestrationStreamChunkResponse {
   /**
    * Parses the chunk response and returns the choice by index.
    * @param index - The index of the choice to find.
-   * @returns An {@link LLMChoiceStreaming} object associated withe index.
+   * @returns An {@link LLMChoiceStreaming} object associated with the index.
    */
   findChoiceByIndex(index: number): LlmChoiceStreaming | undefined {
     return this.getChoices()?.find(


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#306.

## What this PR does and why it is needed

The bug listed on the ticket was resolved by Orchestration in 2506b update. 
Since `role` is now a required field in the response message, `getChoices()` can be safely typed as `LLMChoice[]`.
