### PR TITLE
fix: Zod schema validation for both v3 and v4

### DIFF
--- a/.changeset/cuddly-areas-deny.md
+++ b/.changeset/cuddly-areas-deny.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/langchain': patch
+---
+
+[fix] Use `isInteropZodSchema` instead of `isZodSchemaV4` in LangChain Azure OpenAI and Orchestration clients to support both Zod v3 and v4 schemas.

--- a/packages/langchain/src/openai/util.test.ts
+++ b/packages/langchain/src/openai/util.test.ts
@@ -8,7 +8,10 @@ import {
 import { tool } from '@langchain/core/tools';
 import { toJsonSchema } from '@langchain/core/utils/json_schema';
 import { parseMockResponse } from '../../../../test-util/mock-http.js';
-import { addNumbersSchema } from '../../../../test-util/tools.js';
+import {
+  addNumbersSchema,
+  addNumbersSchemaV3
+} from '../../../../test-util/tools.js';
 import {
   isToolDefinitionLike,
   mapLangChainToAiClient,
@@ -207,7 +210,37 @@ describe('Mapping Functions', () => {
       expect(result).toEqual(expectedOutput);
     });
 
-    it('should map a structured tool with Zod schema', async () => {
+    it('should map a structured tool with Zod V3 schema', async () => {
+      const toolInput = {
+        name: 'test',
+        description: 'Some description',
+        schema: addNumbersSchemaV3
+      };
+      const expectedOutput = {
+        name: 'test',
+        description: 'Some description',
+        parameters: {
+          type: 'object',
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          additionalProperties: false,
+          properties: {
+            a: {
+              type: 'number',
+              description: 'The first number to be added.'
+            },
+            b: {
+              type: 'number',
+              description: 'The second number to be added.'
+            }
+          },
+          required: ['a', 'b']
+        }
+      };
+      const result = mapToolToOpenAiFunction(toolInput);
+      expect(result).toEqual(expectedOutput);
+    });
+
+    it('should map a structured tool with Zod V4 schema', async () => {
       const toolInput = {
         name: 'test',
         description: 'Some description',

--- a/packages/langchain/src/openai/util.ts
+++ b/packages/langchain/src/openai/util.ts
@@ -1,6 +1,6 @@
 import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
 import { v4 as uuidv4 } from 'uuid';
-import { isZodSchemaV4 } from '@langchain/core/utils/types';
+import { isInteropZodSchema } from '@langchain/core/utils/types';
 import { toJsonSchema } from '@langchain/core/utils/json_schema';
 import type { ToolCall, ToolCallChunk } from '@langchain/core/messages/tool';
 import type {
@@ -66,7 +66,7 @@ export function mapToolToOpenAiFunction(
   return {
     name: tool.name,
     description: tool.description,
-    parameters: isZodSchemaV4(tool.schema)
+    parameters: isInteropZodSchema(tool.schema)
       ? toJsonSchema(tool.schema)
       : tool.schema,
     ...(strict !== undefined && { strict })

--- a/packages/langchain/src/orchestration/__snapshots__/util.test.ts.snap
+++ b/packages/langchain/src/orchestration/__snapshots__/util.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`mapOrchestrationChunkToLangChainMessageChunk should map a chunk with content to AIMessageChunk: AIMessageChunk with content 1`] = `
 {

--- a/packages/langchain/src/orchestration/util.test.ts
+++ b/packages/langchain/src/orchestration/util.test.ts
@@ -9,9 +9,14 @@ import {
 import { OrchestrationStreamChunkResponse } from '@sap-ai-sdk/orchestration';
 import { jest } from '@jest/globals';
 import {
+  addNumbersSchema,
+  addNumbersSchemaV3
+} from '../../../../test-util/tools.js';
+import {
   mapLangChainMessagesToOrchestrationMessages,
   mapOutputToChatResult,
-  mapOrchestrationChunkToLangChainMessageChunk
+  mapOrchestrationChunkToLangChainMessageChunk,
+  mapToolToOrchestrationFunction
 } from './util.js';
 import type { OrchestrationMessage } from './orchestration-message.js';
 import type { ToolCallChunk } from '@langchain/core/messages/tool';
@@ -19,7 +24,8 @@ import type {
   CompletionPostResponse,
   MessageToolCall,
   ToolCallChunk as OrchestrationToolCallChunk,
-  CompletionPostResponseStreaming
+  CompletionPostResponseStreaming,
+  FunctionObject
 } from '@sap-ai-sdk/orchestration';
 
 describe('mapLangChainMessagesToOrchestrationMessages', () => {
@@ -268,6 +274,60 @@ describe('mapOutputToChatResult', () => {
         type: 'tool_call'
       }
     ]);
+  });
+});
+
+describe('mapToolToOrchestrationFunction', () => {
+  it('should map zod v3 schemas correctly', () => {
+    const expected: FunctionObject = {
+      name: 'test',
+      description: 'Add two numbers',
+      parameters: {
+        type: 'object',
+        properties: {
+          a: { type: 'number', description: 'The first number to be added.' },
+          b: { type: 'number', description: 'The second number to be added.' }
+        },
+        required: ['a', 'b'],
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        additionalProperties: false
+      }
+    };
+
+    const myTool = {
+      name: 'test',
+      description: 'Add two numbers',
+      schema: addNumbersSchemaV3
+    };
+
+    const result = mapToolToOrchestrationFunction(myTool);
+    expect(result).toEqual(expected);
+  });
+
+  it('should map zod v4 schemas correctly', () => {
+    const expected: FunctionObject = {
+      name: 'test',
+      description: 'Add two numbers',
+      parameters: {
+        type: 'object',
+        properties: {
+          a: { type: 'number', description: 'The first number to be added.' },
+          b: { type: 'number', description: 'The second number to be added.' }
+        },
+        required: ['a', 'b'],
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        additionalProperties: false
+      }
+    };
+
+    const myTool = {
+      name: 'test',
+      description: 'Add two numbers',
+      schema: addNumbersSchema
+    };
+
+    const result = mapToolToOrchestrationFunction(myTool);
+    expect(result).toEqual(expected);
   });
 });
 

--- a/packages/langchain/src/orchestration/util.ts
+++ b/packages/langchain/src/orchestration/util.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { isZodSchemaV4 } from '@langchain/core/utils/types';
+import { isInteropZodSchema } from '@langchain/core/utils/types';
 import { toJsonSchema } from '@langchain/core/utils/json_schema';
 import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
 import type { ToolDefinition } from '@langchain/core/language_models/base';
@@ -63,7 +63,7 @@ export function mapToolToOrchestrationFunction(
   return {
     name: tool.name,
     description: tool.description,
-    parameters: isZodSchemaV4(tool.schema)
+    parameters: isInteropZodSchema(tool.schema)
       ? toJsonSchema(tool.schema)
       : tool.schema,
     ...(strict !== undefined && { strict })

--- a/test-util/tools.ts
+++ b/test-util/tools.ts
@@ -50,7 +50,7 @@ export const multiplyNumbersTool: ChatCompletionTool = {
  * @internal
  */
 export const joke = z.object({
-      setup: z.string().describe('The setup of the joke'),
-      punchline: z.string().describe('The punchline to the joke'),
-      rating: z.number().describe('How funny the joke is, from 1 to 10')
-    });
+  setup: z.string().describe('The setup of the joke'),
+  punchline: z.string().describe('The punchline to the joke'),
+  rating: z.number().describe('How funny the joke is, from 1 to 10')
+});

--- a/test-util/tools.ts
+++ b/test-util/tools.ts
@@ -1,14 +1,25 @@
 // eslint-disable-next-line import/no-internal-modules
-import * as z from 'zod/v4';
+import * as zodV4 from 'zod/v4';
+import * as zodV3 from 'zod/v3';
 import type { ChatCompletionTool } from '../packages/orchestration/src/client/api/schema/index.js';
 
 /**
  * @internal
  */
-export const addNumbersSchema = z
+export const addNumbersSchemaV3 = zodV3
   .object({
-    a: z.number().describe('The first number to be added.'),
-    b: z.number().describe('The second number to be added.')
+    a: zodV3.number().describe('The first number to be added.'),
+    b: zodV3.number().describe('The second number to be added.')
+  })
+  .strict();
+
+/**
+ * @internal
+ */
+export const addNumbersSchema = zodV4
+  .object({
+    a: zodV4.number().describe('The first number to be added.'),
+    b: zodV4.number().describe('The second number to be added.')
   })
   .strict();
 
@@ -20,17 +31,17 @@ export const addNumbersTool: ChatCompletionTool = {
   function: {
     name: 'add',
     description: 'Adds two numbers',
-    parameters: z.toJSONSchema(addNumbersSchema)
+    parameters: zodV4.toJSONSchema(addNumbersSchema)
   }
 };
 
 /**
  * @internal
  */
-const multiplyNumbersSchema = z
+const multiplyNumbersSchema = zodV4
   .object({
-    a: z.number().describe('The first number to multiply.'),
-    b: z.number().describe('The second number to multiply.')
+    a: zodV4.number().describe('The first number to multiply.'),
+    b: zodV4.number().describe('The second number to multiply.')
   })
   .strict();
 
@@ -42,15 +53,15 @@ export const multiplyNumbersTool: ChatCompletionTool = {
   function: {
     name: 'multiply',
     description: 'Multiplies two numbers',
-    parameters: z.toJSONSchema(multiplyNumbersSchema)
+    parameters: zodV4.toJSONSchema(multiplyNumbersSchema)
   }
 };
 
 /**
  * @internal
  */
-export const joke = z.object({
-  setup: z.string().describe('The setup of the joke'),
-  punchline: z.string().describe('The punchline to the joke'),
-  rating: z.number().describe('How funny the joke is, from 1 to 10')
+export const joke = zodV4.object({
+  setup: zodV4.string().describe('The setup of the joke'),
+  punchline: zodV4.string().describe('The punchline to the joke'),
+  rating: zodV4.number().describe('How funny the joke is, from 1 to 10')
 });


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#371.
User issue: SAP/ai-sdk-js#870

## What this PR does and why it is needed

Use `isInteropZodSchema` instead of `isZodSchemaV4` to support both Zod v3 and v4 schema input from user.
