### PR TITLE
fix: E2E with structured output

### DIFF
--- a/sample-code/src/langchain-azure-openai.ts
+++ b/sample-code/src/langchain-azure-openai.ts
@@ -233,7 +233,11 @@ export async function streamChain(
  * With Structured Output using `jsonSchema` option with `strict: true`.
  * @returns The answer from GPT with exactly the structure defined in the schema.
  */
-export async function invokeWithStructuredOutputJsonSchema(): Promise<string> {
+export async function invokeWithStructuredOutputJsonSchema(): Promise<{
+  setup: string;
+  punchline: string;
+  rating: number;
+}> {
   // initialize client with options
   const llm = new AzureOpenAiChatClient({
     modelName: 'gpt-4o'
@@ -249,8 +253,7 @@ export async function invokeWithStructuredOutputJsonSchema(): Promise<string> {
     strict: true
   });
 
-  const finalResponse = await structuredLlm.invoke('Tell me a joke about cats');
-  return JSON.stringify(finalResponse);
+  return structuredLlm.invoke('Tell me a joke about cats');
 }
 
 /**


### PR DESCRIPTION
## Context

E2E was failing https://github.com/SAP/ai-sdk-js/actions/runs/16482805208

Returning object instead of JSON string to make it work.