### PR TITLE
chore: Add weather MCP in agent tutorial

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,9 +243,15 @@ importers:
       '@langchain/langgraph':
         specifier: ^0.3.11
         version: 0.3.11(@langchain/core@0.3.66(openai@5.9.2(ws@8.18.3)(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))
+      '@langchain/mcp-adapters':
+        specifier: ^0.6.0
+        version: 0.6.0(@langchain/core@0.3.66(openai@5.9.2(ws@8.18.3)(zod@3.25.76)))
       '@langchain/textsplitters':
         specifier: 0.1.0
         version: 0.1.0(@langchain/core@0.3.66(openai@5.9.2(ws@8.18.3)(zod@3.25.76)))
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.13.1
+        version: 1.17.0
       '@sap-ai-sdk/ai-api':
         specifier: workspace:^
         version: link:../packages/ai-api
@@ -1147,6 +1153,12 @@ packages:
       zod-to-json-schema:
         optional: true
 
+  '@langchain/mcp-adapters@0.6.0':
+    resolution: {integrity: sha512-NHQNH9NciLhxlCnL/4HDebiYT3UQvpBfF5KPlIi/uSXn8te/bYjPV64gUyAloNNo+fjj4qDvKP1/nHj0r7fKFw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^0.3.66
+
   '@langchain/openai@0.6.0':
     resolution: {integrity: sha512-pBU+a5/T+ITVtVD6EefKHCDZtzHswOVB0aMfuUscDgpZxg5EQITyvI2If2InnZ165F1vAoQD9nsWNeiV9FsHpg==}
     engines: {node: '>=18'}
@@ -1164,6 +1176,10 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@modelcontextprotocol/sdk@1.17.0':
+    resolution: {integrity: sha512-qFfbWFA7r1Sd8D697L7GkTd36yqDuTkvz0KfOGkgXR8EUhQn3/EDNIR/qUdQNMT8IjmasBvHWuXeisxtXTQT2g==}
+    engines: {node: '>=18'}
 
   '@mswjs/interceptors@0.39.3':
     resolution: {integrity: sha512-9bw/wBL7pblsnOCIqvn1788S9o4h+cC5HWXg0Xhh0dOzsZ53IyfmBM+FYqpDDPbm0xjCqEqvCITloF3Dm4TXRQ==}
@@ -2203,6 +2219,10 @@ packages:
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -2647,6 +2667,14 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  eventsource-parser@3.0.3:
+    resolution: {integrity: sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==}
+    engines: {node: '>=20.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -2671,6 +2699,12 @@ packages:
     resolution: {integrity: sha512-P0te2pt+hHI5qLJkIR+iMvS+lYUZml8rKKsohVHAGY+uClp9XVbdyYNJOIjSRpHVp8s8YqxJCiHUkSYZGr8rtQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
@@ -2681,6 +2715,9 @@ packages:
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  extended-eventsource@1.7.0:
+    resolution: {integrity: sha512-s8rtvZuYcKBpzytHb5g95cHbZ1J99WeMnV18oKc5wKoxkHzlzpPc/bNAm7Da2Db0BDw0CAu1z3LpH+7UsyzIpw==}
 
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -3966,6 +4003,10 @@ packages:
   oas-validator@5.0.8:
     resolution: {integrity: sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -4175,6 +4216,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -6060,6 +6105,17 @@ snapshots:
       - react
       - react-dom
 
+  '@langchain/mcp-adapters@0.6.0(@langchain/core@0.3.66(openai@5.9.2(ws@8.18.3)(zod@3.25.76)))':
+    dependencies:
+      '@langchain/core': 0.3.66(openai@5.9.2(ws@8.18.3)(zod@3.25.76))
+      '@modelcontextprotocol/sdk': 1.17.0
+      debug: 4.4.1
+      zod: 3.25.76
+    optionalDependencies:
+      extended-eventsource: 1.7.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@langchain/openai@0.6.0(@langchain/core@0.3.66(openai@5.9.2(ws@8.18.3)(zod@3.25.76)))(ws@8.18.3)':
     dependencies:
       '@langchain/core': 0.3.66(openai@5.9.2(ws@8.18.3)(zod@3.25.76))
@@ -6089,6 +6145,23 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@modelcontextprotocol/sdk@1.17.0':
+    dependencies:
+      ajv: 6.12.6
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.3
+      express: 5.1.0
+      express-rate-limit: 7.5.1(express@5.1.0)
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mswjs/interceptors@0.39.3':
     dependencies:
@@ -6333,7 +6406,7 @@ snapshots:
       eslint: 9.32.0
       eslint-config-prettier: 10.1.8(eslint@9.32.0)
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.8.3))(eslint@9.32.0))(eslint@9.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.8.3))(eslint@9.32.0))(eslint@9.32.0))(eslint@9.32.0)
       eslint-plugin-jsdoc: 51.4.1(eslint@9.32.0)
       eslint-plugin-prettier: 5.5.3(eslint-config-prettier@10.1.8(eslint@9.32.0))(eslint@9.32.0)(prettier@3.6.2)
       eslint-plugin-regex: 1.10.0(eslint@9.32.0)
@@ -7537,6 +7610,11 @@ snapshots:
 
   core-util-is@1.0.2: {}
 
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -7912,7 +7990,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.8.3))(eslint@9.32.0))(eslint@9.32.0))(eslint@9.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7927,7 +8005,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.32.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.8.3))(eslint@9.32.0))(eslint@9.32.0))(eslint@9.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8070,6 +8148,12 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  eventsource-parser@3.0.3: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.3
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8108,6 +8192,10 @@ snapshots:
       jest-message-util: 30.0.5
       jest-mock: 30.0.5
       jest-util: 30.0.5
+
+  express-rate-limit@7.5.1(express@5.1.0):
+    dependencies:
+      express: 5.1.0
 
   express@4.21.2:
     dependencies:
@@ -8178,6 +8266,9 @@ snapshots:
       - supports-color
 
   extendable-error@0.1.7: {}
+
+  extended-eventsource@1.7.0:
+    optional: true
 
   external-editor@3.1.0:
     dependencies:
@@ -9616,6 +9707,8 @@ snapshots:
       should: 13.2.3
       yaml: 1.10.2
 
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -9836,6 +9929,8 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.0: {}
 
   pkg-dir@4.2.0:
     dependencies:

--- a/sample-code/package.json
+++ b/sample-code/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "@langchain/langgraph": "^0.3.11",
+    "@langchain/mcp-adapters": "^0.6.0",
+    "@modelcontextprotocol/sdk": "^1.13.1",
     "langchain": "0.3.30",
     "@langchain/core": "0.3.66",
     "@langchain/textsplitters": "0.1.0",

--- a/sample-code/src/tutorials/agent-openai-langchain.ts
+++ b/sample-code/src/tutorials/agent-openai-langchain.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console import/no-internal-modules */
 import {
   StateGraph,
   MessagesAnnotation,
@@ -8,47 +8,22 @@ import {
   interrupt,
   Command
 } from '@langchain/langgraph';
-// eslint-disable-next-line import/no-internal-modules
 import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { AzureOpenAiChatClient } from '@sap-ai-sdk/langchain';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { tool } from '@langchain/core/tools';
-// eslint-disable-next-line import/no-internal-modules
 import * as z from 'zod/v4';
 import type { AIMessage } from '@langchain/core/messages';
+import { getWeatherTools } from './mcp/mcp-adapter.js';
 /**
  * This example demonstrates how to create a travel itinerary assistant using LangGraph.
  * The assistant can check the weather and recommend restaurants based on the city provided.
  * It uses tools to fetch weather and restaurant data, and maintains conversation context.
  */
-const mockWeatherData: Record<
-  string,
-  { temperature: string; condition: string }
-> = {
-  paris: { temperature: '22°C', condition: 'Mild and pleasant' },
-  reykjavik: { temperature: '3°C', condition: 'Cold and windy' }
-};
-
 const mockRestaurantData: Record<string, string[]> = {
   paris: ['Le Comptoir du Relais', "L'As du Fallafel", 'Breizh Café'],
   reykjavik: ['Dill Restaurant', 'Fish Market', 'Grillmarkaðurinn']
 };
-
-const getWeatherTool = tool(
-  async ({ city }) => {
-    const weather = mockWeatherData[city.toLowerCase()];
-    return weather
-      ? `Current weather in ${city}: ${weather.temperature}, ${weather.condition}`
-      : `Weather data not available for ${city}.`;
-  },
-  {
-    name: 'get_weather',
-    description: 'Get current weather information for a city',
-    schema: z.object({
-      city: z.string().meta({ description: 'The city name' })
-    })
-  }
-);
 
 const getRestaurantsTool = tool(
   async ({ city }) => {
@@ -67,7 +42,7 @@ const getRestaurantsTool = tool(
 );
 
 // Define the tools for the agent to use
-const tools = [getWeatherTool, getRestaurantsTool];
+const tools = [...getWeatherTools, getRestaurantsTool];
 const toolNode = new ToolNode(tools);
 
 // Create a model

--- a/sample-code/src/tutorials/mcp/mcp-adapter.ts
+++ b/sample-code/src/tutorials/mcp/mcp-adapter.ts
@@ -1,0 +1,16 @@
+import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+
+// Create client and connect to server
+const client = new MultiServerMCPClient({
+  throwOnLoadError: true,
+  prefixToolNameWithServerName: false,
+  additionalToolNamePrefix: "",
+  useStandardContentBlocks: true,
+  mcpServers: {
+     weather: {
+      command: "npx",
+      args: ["tsx", "./src/tutorials/mcp-server/weather-mcp.ts"]
+    }
+  }
+});
+export const getWeatherTools = await client.getTools()

--- a/sample-code/src/tutorials/mcp/weather-mcp-server.ts
+++ b/sample-code/src/tutorials/mcp/weather-mcp-server.ts
@@ -1,0 +1,58 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from "zod";
+
+const server = new McpServer({
+  name: "Weather Server",
+  version: "1.0.0"
+});
+
+server.tool(
+  'get-weather',
+  'Tool to get the weather of a city',
+  {
+    city: z.string().describe("The name of the city to get the weather for")
+  },
+  async({ city }) => {
+    try {
+      const response = await fetch(`https://geocoding-api.open-meteo.com/v1/search?name=${city}&count=10&language=en&format=json`);
+      const data = await response.json();
+      
+      if (data.results.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `No results found for city: ${city}`
+            }
+          ]
+        };
+      }
+      
+      const { latitude, longitude } = data.results[0];
+      const weatherResponse = await fetch(`https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&hourly=temperature_2m,precipitation,apparent_temperature,relative_humidity_2m&forecast_days=1`);
+      
+      const weatherData = await weatherResponse.json();
+      
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(weatherData, null, 2)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error fetching weather data: ${(error as Error).message}`
+          }
+        ]
+      };
+    }
+  });
+
+const transport = new StdioServerTransport();
+server.connect(transport);


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

Most weather mcp servers here https://github.com/modelcontextprotocol/servers are based on Accuweather/OpenWeathermap which require an API key with payment option. `Open-meteo` is a nice free API but the [mcp server](https://github.com/isdaniel/mcp_weather_server) is python based. To make setup as simple as possible (no additional unrelated prerequisites), I would prefer a TS based MCP server which also does not require a dedicated API key. 

https://github.com/microsoft/lets-learn-mcp-javascript provides that, but since this is a "lets-learn" project, and could potentially change, @ZhongpinWang suggested copying the code over. Its also a single file:   
https://github.com/microsoft/lets-learn-mcp-javascript/blob/main/main.ts.

I will update our tutorial docs. 

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
