### PR TITLE
chore: Adapt v1 documentation path

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -67,7 +67,7 @@ jobs:
           git config --local user.name "SAP Cloud SDK Bot"
           BRANCH_NAME="update-release-notes-js-${{ needs.bump.outputs.version }}"
           git checkout -b "${BRANCH_NAME}"
-          git add docs-js/release-notes.mdx
+          git add docs-js_versioned_docs/version-v1/release-notes.mdx
           if git diff --staged --quiet; then
             echo "No changes to commit."
             # Output an empty pr_url if no changes
@@ -89,7 +89,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
 
-#Added as a separate job to avoid running into incompatibility issues with pnpm and npm
+  #Added as a separate job to avoid running into incompatibility issues with pnpm and npm
   lint-docs:
     name: Run Lint Fix on Docs
     runs-on: ubuntu-latest
@@ -124,7 +124,7 @@ jobs:
         run: |
           git config --local user.email "cloudsdk@sap.com"
           git config --local user.name "SAP Cloud SDK Bot"
-          git add docs-js/release-notes.mdx
+          git add docs-js_versioned_docs/version-v1/release-notes.mdx
           if git diff --staged --quiet; then
             echo "No lint fixes to commit"
           else


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#361.

- [x] I know which base branch I chose for this PR, as the default branch is `v1-main` now, which is not for v2 development.
- ~[ ] If my change will be merged into the `main` branch (for v2), I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2~

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
