### PR TITLE
chore!: Pass `signal` instead of abort controller in the `stream()` method

### DIFF
--- a/packages/foundation-models/src/azure-openai/azure-openai-chat-client.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-chat-client.ts
@@ -44,17 +44,23 @@ export class AzureOpenAiChatClient {
   /**
    * Creates a completion stream for the chat messages.
    * @param data - The input parameters for the chat completion.
-   * @param controller - The abort controller.
+   * @param signal - The abort signal.
    * @param requestConfig - The request configuration.
    * @returns A response containing the chat completion stream.
    */
   async stream(
     data: AzureOpenAiCreateChatCompletionRequest,
-    controller = new AbortController(),
+    signal?: AbortSignal,
     requestConfig?: CustomRequestConfig
   ): Promise<
     AzureOpenAiChatCompletionStreamResponse<AzureOpenAiChatCompletionStreamChunkResponse>
   > {
+    const controller = new AbortController();
+    if (signal) {
+      signal.addEventListener('abort', () => {
+        controller.abort();
+      });
+    }
     const response =
       new AzureOpenAiChatCompletionStreamResponse<AzureOpenAiChatCompletionStreamChunkResponse>();
     response.stream = (await this.createStream(data, controller, requestConfig))

--- a/packages/langchain/src/openai/chat.ts
+++ b/packages/langchain/src/openai/chat.ts
@@ -352,17 +352,12 @@ export class AzureOpenAiChatClient extends BaseChatModel<AzureOpenAiChatCallOpti
       {
         signal: options.signal
       },
-      () => {
-        const controller = new AbortController();
-        if (options.signal) {
-          options.signal.addEventListener('abort', () => controller.abort());
-        }
-        return this.openAiChatClient.stream(
+      () =>
+        this.openAiChatClient.stream(
           mapLangChainToAiClient(this, messages, options),
-          controller,
+          options.signal,
           options.requestConfig
-        );
-      }
+        )
     );
 
     for await (const chunk of response.stream) {

--- a/packages/langchain/src/orchestration/client.ts
+++ b/packages/langchain/src/orchestration/client.ts
@@ -168,18 +168,13 @@ export class OrchestrationClient extends BaseChatModel<
       {
         signal: options.signal
       },
-      () => {
-        const controller = new AbortController();
-        if (options.signal) {
-          options.signal.addEventListener('abort', () => controller.abort());
-        }
-        return orchestrationClient.stream(
+      () =>
+        orchestrationClient.stream(
           { messages: orchestrationMessages, placeholderValues },
-          controller,
+          options.signal,
           options.streamOptions,
           customRequestConfig
-        );
-      }
+        )
     );
 
     for await (const chunk of response.stream) {

--- a/packages/orchestration/src/orchestration-client.test.ts
+++ b/packages/orchestration/src/orchestration-client.test.ts
@@ -930,7 +930,9 @@ describe('orchestration service client', () => {
 
       const client = new OrchestrationClient(config);
 
-      await expect(client.stream(undefined, controller)).rejects.toThrow();
+      await expect(
+        client.stream(undefined, controller.signal)
+      ).rejects.toThrow();
     });
 
     it('should throw error when stream is called with already aborted controller', async () => {
@@ -958,7 +960,9 @@ describe('orchestration service client', () => {
 
       const client = new OrchestrationClient(config);
 
-      await expect(client.stream(undefined, controller)).rejects.toThrow();
+      await expect(
+        client.stream(undefined, controller.signal)
+      ).rejects.toThrow();
     });
   });
 });

--- a/packages/orchestration/src/orchestration-client.ts
+++ b/packages/orchestration/src/orchestration-client.ts
@@ -69,10 +69,17 @@ export class OrchestrationClient {
 
   async stream(
     request?: ChatCompletionRequest,
-    controller = new AbortController(),
+    signal?: AbortSignal,
     options?: StreamOptions,
     requestConfig?: CustomRequestConfig
   ): Promise<OrchestrationStreamResponse<OrchestrationStreamChunkResponse>> {
+    const controller = new AbortController();
+    if (signal) {
+      signal.addEventListener('abort', () => {
+        controller.abort();
+      });
+    }
+
     try {
       if (typeof this.config === 'string' && options) {
         logger.warn(

--- a/sample-code/src/foundation-models/azure-openai.ts
+++ b/sample-code/src/foundation-models/azure-openai.ts
@@ -35,11 +35,11 @@ export async function chatCompletion(): Promise<AzureOpenAiChatCompletionRespons
 
 /**
  * Ask Azure OpenAI model about SAP Cloud SDK with streaming.
- * @param controller - The abort controller.
+ * @param signal - The abort signal.
  * @returns The response from Azure OpenAI containing the response content.
  */
 export async function chatCompletionStream(
-  controller: AbortController
+  signal: AbortSignal
 ): Promise<
   AzureOpenAiChatCompletionStreamResponse<AzureOpenAiChatCompletionStreamChunkResponse>
 > {
@@ -52,7 +52,7 @@ export async function chatCompletionStream(
         }
       ]
     },
-    controller
+    signal
   );
   return response;
 }

--- a/sample-code/src/orchestration.ts
+++ b/sample-code/src/orchestration.ts
@@ -88,7 +88,7 @@ export async function chatCompletionStream(
         }
       ]
     },
-    controller,
+    controller.signal,
     streamOptions
   );
 }
@@ -149,7 +149,7 @@ export async function chatCompletionStreamWithJsonModuleConfig(
 
   return orchestrationClient.stream(
     { placeholderValues: { input: 'SAP Cloud SDK' } },
-    controller
+    controller.signal
   );
 }
 
@@ -764,7 +764,7 @@ export async function chatCompletionStreamWithTools(
         { role: 'user', content: 'Add the numbers 2 and 3, as well as 4 and 5' }
       ]
     },
-    controller,
+    controller.signal,
     streamOptions
   );
 }

--- a/sample-code/src/server.ts
+++ b/sample-code/src/server.ts
@@ -180,7 +180,7 @@ app.get('/azure-openai/chat-completion-with-destination', async (req, res) => {
 app.get('/azure-openai/chat-completion-stream', async (req, res) => {
   const controller = new AbortController();
   try {
-    const response = await azureChatCompletionStream(controller);
+    const response = await azureChatCompletionStream(controller.signal);
 
     // Set headers for event stream.
     res.setHeader('Content-Type', 'text/event-stream');


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#345.

- [x] I know which base branch I chose for this PR, as the default branch is `v1-main` now, which is not for v2 development.
- [x] If my change will be merged into the `main` branch (for v2), I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2

## What this PR does and why it is needed

Before `client.stream(data, abortController, requestConfig);`
After `client.stream(data, abortController.signal, requestConfig);`

The previous design of passing a controller is unnecessary.

