### PR TITLE
chore: Add pnpm lockfile autofix workflow back

### DIFF
--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -1,0 +1,36 @@
+name: Update pnpm-lock.yaml for Dependabot PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+    paths:
+      - '**/package.json'
+    branches:
+      - v1-main
+  workflow_dispatch:
+
+jobs:
+  update-lockfile:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Setup Environment
+        uses: sap/ai-sdk-js/.github/actions/setup@main
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
+          pnpm-install-args: --lockfile-only
+
+      - name: Commit and push if changed
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config --global user.email "cloud-sdk-js@github.com"
+            git config --global user.name "cloud-sdk-js"  
+            git add pnpm-lock.yaml
+            git commit -m "chore: update pnpm-lock.yaml"
+            git push
+          fi


### PR DESCRIPTION
## Context

Need this workflow to fix the dependabot errors on v1-main. 

- [x] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- [ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2
- [x] I have created a PR for `v1-main`, if my changes need to be backported to v1.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
