### PR TITLE
chore: Add `branches` to the pnpm dependabot workflow 

### DIFF
--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize]
     paths:
       - '**/package.json'
+    branches:
+      - main
+      - v1-main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

- [ ] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- [ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2
- [ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
