### PR TITLE
chore: Add deploymentId as optional

### DIFF
--- a/packages/orchestration/src/orchestration-client.ts
+++ b/packages/orchestration/src/orchestration-client.ts
@@ -15,7 +15,9 @@ import type {
   HttpResponse,
   CustomRequestConfig
 } from '@sap-cloud-sdk/http-client';
-import type { ResourceGroupConfig } from '@sap-ai-sdk/ai-api/internal.js';
+import type {
+  DeploymentIdConfig,
+  ResourceGroupConfig } from '@sap-ai-sdk/ai-api/internal.js';
 import type {
   OrchestrationModuleConfig,
   ChatCompletionRequest,
@@ -42,7 +44,7 @@ export class OrchestrationClient {
    */
   constructor(
     private config: OrchestrationModuleConfig | string,
-    private deploymentConfig?: ResourceGroupConfig,
+    private deploymentConfig?: Partial<ResourceGroupConfig & DeploymentIdConfig>,
     private destination?: HttpDestinationOrFetchOptions
   ) {
     if (typeof config === 'string') {


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#148.

- [ ] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- [ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2
- [ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.

## What this PR does and why it is needed

Add deploymentId to allow user to provide in certain cases.
