### PR TITLE
feat: Add resolve deployment url

### DIFF
--- a/.changeset/tiny-trains-tap.md
+++ b/.changeset/tiny-trains-tap.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/ai-api': minor
+---
+
+[New Functionality] Add `resolveDeploymentUrl()` function to get deployment URL matches the given criteria.


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

- [x] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- ~[ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2~
- ~[ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.~

## What this PR does and why it is needed

Support resolve deployment url with the given criteria. Usage example:

```ts
const url = await resolveDeploymentUrl({
  scenarioId: 'foundation-models',
  model: { name: 'gpt-4o' }
});
```
