### PR TITLE
fix: E2E stream signal param

### DIFF
--- a/tests/e2e-tests/src/orchestration.test.ts
+++ b/tests/e2e-tests/src/orchestration.test.ts
@@ -139,17 +139,15 @@ describe('orchestration', () => {
     };
 
     try {
-      await new OrchestrationClient(config).stream(
-        {
-          messages: [
-            {
-              role: 'user',
-              content: 'Give me a short introduction on {{ ?__input__ }}.'
-            }
-          ],
-          placeholderValues: { __input__: 'SAP Cloud SDK' }
-        }
-      );
+      await new OrchestrationClient(config).stream({
+        messages: [
+          {
+            role: 'user',
+            content: 'Give me a short introduction on {{ ?__input__ }}.'
+          }
+        ],
+        placeholderValues: { __input__: 'SAP Cloud SDK' }
+      });
     } catch (err: any) {
       expect(err.stack).toContain(
         'Caused by:\nHTTP Response: Request failed with status code 400'

--- a/tests/e2e-tests/src/orchestration.test.ts
+++ b/tests/e2e-tests/src/orchestration.test.ts
@@ -148,8 +148,7 @@ describe('orchestration', () => {
             }
           ],
           placeholderValues: { __input__: 'SAP Cloud SDK' }
-        },
-        new AbortController()
+        }
       );
     } catch (err: any) {
       expect(err.stack).toContain(


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

- [ ] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- [ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2
- [ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

e2e was failing due to passing the old controller to signal param.
