### PR TITLE
fix: E2E get intermediate results

### DIFF
--- a/tests/e2e-tests/src/document-grounding.test.ts
+++ b/tests/e2e-tests/src/document-grounding.test.ts
@@ -27,8 +27,8 @@ describe('document grounding', () => {
       'help.sap.com'
     );
     expect(result.getContent()).toEqual(expect.any(String));
-    expect(result.data.intermediate_results).toBeDefined();
-    expect(result.data.intermediate_results.grounding!.data).toBeDefined();
+    expect(result.getIntermediateResults()).toBeDefined();
+    expect(result.getIntermediateResults().grounding!.data).toBeDefined();
   });
 
   it('should get the result based on grounding context from SharePoint data respository via orchestration API', async () => {
@@ -38,8 +38,8 @@ describe('document grounding', () => {
       ['0bd2adc2-8d0d-478a-94f6-a0c10958f602']
     );
     expect(result.getContent()).toContain('&)UPnkL_izT)&1u%?2Kg*Y.@qFqR@/');
-    expect(result.data.intermediate_results).toBeDefined();
-    expect(result.data.intermediate_results.grounding!.data).toBeDefined();
+    expect(result.getIntermediateResults()).toBeDefined();
+    expect(result.getIntermediateResults().grounding!.data).toBeDefined();
   });
 
   it('should get the result based on grounding context from S3 data respository via orchestration API', async () => {
@@ -49,8 +49,8 @@ describe('document grounding', () => {
       ['8907272b-682e-4574-b8b8-9b75c393f362']
     );
     expect(result.getContent()).toContain('Dubai Chocolate');
-    expect(result.data.intermediate_results).toBeDefined();
-    expect(result.data.intermediate_results.grounding!.data).toBeDefined();
+    expect(result.getIntermediateResults()).toBeDefined();
+    expect(result.getIntermediateResults().grounding!.data).toBeDefined();
   });
 
   it('should get the pipeline status', async () => {

--- a/tests/e2e-tests/src/orchestration.test.ts
+++ b/tests/e2e-tests/src/orchestration.test.ts
@@ -26,9 +26,9 @@ loadEnv();
 
 describe('orchestration', () => {
   const assertContent = (response: OrchestrationResponse) => {
-    expect(response.data.intermediate_results).toBeDefined();
-    expect(response.data.intermediate_results.templating).not.toHaveLength(0);
-    expect(response.data.final_result.choices).not.toHaveLength(0);
+    expect(response.getIntermediateResults()).toBeDefined();
+    expect(response.getIntermediateResults().templating).not.toHaveLength(0);
+    expect(response.findChoiceByIndex(0)).toBeDefined();
     expect(response.getContent()).toEqual(expect.any(String));
     expect(response.getFinishReason()).toEqual('stop');
   };
@@ -58,9 +58,9 @@ describe('orchestration', () => {
   it('should trigger an output filter', async () => {
     const response = await orchestrationOutputFiltering();
 
-    expect(response.data.intermediate_results).toBeDefined();
+    expect(response.getIntermediateResults()).toBeDefined();
     expect(
-      response.data.intermediate_results.output_filtering!.data
+      response.getIntermediateResults().output_filtering!.data
     ).toBeDefined();
     expect(response.getContent).toThrow(Error);
     expect(response.getFinishReason()).toEqual('content_filter');
@@ -80,7 +80,7 @@ describe('orchestration', () => {
   it('should complete a chat with masked grounding input', async () => {
     const response = await orchestrationMaskGroundingInput();
     const parsedGroundingInput =
-      response.data.intermediate_results.input_masking!.data!
+      response.getIntermediateResults().input_masking!.data!
         .masked_grounding_input[0];
     expect(parsedGroundingInput).toEqual(
       "What is MASKED_ORG_1's product Joule?"


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

- [x] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- ~[ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2~
- ~[ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.~

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

Forgot to update E2E in the API facade ticket. 😬