### PR TITLE
(v1)chore: Remove deprecated models

### DIFF
--- a/.changeset/clean-guests-drum.md
+++ b/.changeset/clean-guests-drum.md
@@ -2,4 +2,4 @@
 '@sap-ai-sdk/core': minor
 ---
 
-[Improvement] Add `gpt-5`,`gpt-5-mini` and `gpt-5-nano` to the available model list.
+[Improvement] Add `gpt-5`,`gpt-5-mini` and `gpt-5-nano` to and remove `gemini-1.5-flash`, `gemini-1.5-pro` and `ibm--granite-13b-chat` from the available model list.

--- a/packages/core/src/model-types.ts
+++ b/packages/core/src/model-types.ts
@@ -29,8 +29,6 @@ export type AzureOpenAiEmbeddingModel = LiteralUnion<
  * GCP Vertex AI models for chat completion.
  */
 export type GcpVertexAiChatModel = LiteralUnion<
-  | 'gemini-1.5-pro'
-  | 'gemini-1.5-flash'
   | 'gemini-2.0-flash'
   | 'gemini-2.0-flash-lite'
   | 'gemini-2.5-flash'
@@ -60,7 +58,6 @@ export type AwsBedrockChatModel = LiteralUnion<
 export type AiCoreOpenSourceChatModel = LiteralUnion<
   | 'mistralai--mistral-large-instruct'
   | 'mistralai--mistral-small-instruct'
-  | 'ibm--granite-13b-chat'
   | 'alephalpha-pharia-1-7b-control'
   | 'deepseek-ai--deepseek-r1'
 >;


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#382.

- [x] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- ~[ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2~
- [x] I have created a PR for `v1-main`, if my changes need to be backported to v1.

## What this PR does and why it is needed

Deprecate `gemini-1.5-flash`, `gemini-1.5-pro` and `ibm--granite-13b-chat`.
