### PR TITLE
fix: Update spec path

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -98,7 +98,7 @@ jobs:
               FILE_PATH='packages/orchestration/src/spec/api.yaml'
               ;;
             prompt-registry)
-              API_URL="repos/AI/prompt-registry/contents/src/spec/prompt-registry.yaml?ref=$REF"
+              API_URL="repos/AI/prompt-registry/contents/src/spec/generated/prompt-registry-combined.yaml?ref=$REF"
               FILE_PATH='packages/prompt-registry/src/spec/prompt-registry.yaml'
               ;;
           esac


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

- [ ] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- [ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2
- [ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
