### PR TITLE
fix: Read `vars` from input instead of `default`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Setup repo, node and pnpm.
 inputs:
   node-version:
     description: 'Node.js version'
-    default: ${{ vars.DEFAULT_NODE_VERSION }}
+    default: '22'
   registry-url:
     description: 'The registry URL to use for npm packages'
     default: 'https://registry.npmjs.org'

--- a/.github/workflows/auto-fix-lint.yml
+++ b/.github/workflows/auto-fix-lint.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
+          node-version: ${{ vars.DEFAULT_NODE_VERSION }}
       - run: pnpm lint:fix
       - name: Commit Changes if needed
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: ${{ fromJSON(vars.SUPPORTED_NODE_VERSIONS) }}
 
     steps:
-      - uses: sap/ai-sdk-js/.github/actions/setup@fix-default-node-version-with-vars
+      - uses: sap/ai-sdk-js/.github/actions/setup@main
         with:
           node-version: ${{ matrix.node-version }}
       - run: pnpm test:unit
@@ -25,7 +25,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: sap/ai-sdk-js/.github/actions/setup@fix-default-node-version-with-vars
+      - uses: sap/ai-sdk-js/.github/actions/setup@main
         with:
           node-version: ${{ vars.DEFAULT_NODE_VERSION }}
       - name: REUSE Compliance Check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: ${{ fromJSON(vars.SUPPORTED_NODE_VERSIONS) }}
 
     steps:
-      - uses: sap/ai-sdk-js/.github/actions/setup@main
+      - uses: sap/ai-sdk-js/.github/actions/setup@fix-default-node-version-with-vars
         with:
           node-version: ${{ matrix.node-version }}
       - run: pnpm test:unit
@@ -25,7 +25,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: sap/ai-sdk-js/.github/actions/setup@main
+      - uses: sap/ai-sdk-js/.github/actions/setup@fix-default-node-version-with-vars
         with:
           node-version: ${{ vars.DEFAULT_NODE_VERSION }}
       - name: REUSE Compliance Check
@@ -45,14 +45,14 @@ jobs:
       - name: Set NODE_PATH
         run: echo "NODE_PATH=$(pwd)/node_modules" >> $GITHUB_ENV
       - name: Check public API
-        uses: sap/cloud-sdk-js/.github/actions/check-public-api@main
+        uses: sap/cloud-sdk-js/.github/actions/check-public-api@fix-default-node-version-with-vars
         with:
           force_internal_exports: 'false'
           ignored_path_pattern: '.*?/client/.*?/schema|.*?/zod/.*?'
       - name: Check dependencies
         run: pnpm check:deps
       - name: License Check
-        uses: sap/cloud-sdk-js/.github/actions/check-license@main
+        uses: sap/cloud-sdk-js/.github/actions/check-license@fix-default-node-version-with-vars
 
   dependabot:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Check dependencies
         run: pnpm check:deps
       - name: License Check
-        uses: sap/cloud-sdk-js/.github/actions/check-license@fix-default-node-version-with-vars
+        uses: sap/cloud-sdk-js/.github/actions/check-license@main
 
   dependabot:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: sap/ai-sdk-js/.github/actions/setup@main
+        with:
+          node-version: ${{ vars.DEFAULT_NODE_VERSION }}
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v5
       - run: pnpm generate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set NODE_PATH
         run: echo "NODE_PATH=$(pwd)/node_modules" >> $GITHUB_ENV
       - name: Check public API
-        uses: sap/cloud-sdk-js/.github/actions/check-public-api@fix-default-node-version-with-vars
+        uses: sap/cloud-sdk-js/.github/actions/check-public-api@main
         with:
           force_internal_exports: 'false'
           ignored_path_pattern: '.*?/client/.*?/schema|.*?/zod/.*?'

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -22,7 +22,6 @@ jobs:
 # env:
 #   DOCS_REPO: SAP/ai-sdk
 #   DOCS_CHECKOUT_PATH: ./ai-sdk-docs
-#   NODE_VERSION: ${{ vars.DEFAULT_NODE_VERSION }}
 
 # jobs:
 #   bump:
@@ -34,6 +33,7 @@ jobs:
 #         with:
 #           token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
 #           ref: 'main'
+#           node-version: ${{ vars.DEFAULT_NODE_VERSION }}
 #       - name: bump version
 #         uses: sap/cloud-sdk-js/.github/actions/changesets-fixed-version-bump@main
 #         id: bump
@@ -60,7 +60,7 @@ jobs:
 #       - name: Checkout current repository
 #         uses: sap/ai-sdk-js/.github/actions/setup@main
 #         with:
-#           node-version: ${{ env.NODE_VERSION }}
+#           node-version: ${{ vars.DEFAULT_NODE_VERSION }}
 #       - name: Checkout Docs Repo
 #         uses: actions/checkout@v4
 #         with:
@@ -120,7 +120,7 @@ jobs:
 #       - name: Setup Node.js
 #         uses: actions/setup-node@v4
 #         with:
-#           node-version: ${{ env.NODE_VERSION }}
+#           node-version: ${{ vars.DEFAULT_NODE_VERSION }}
 
 #       - name: Install Dependencies
 #         working-directory: ${{ env.DOCS_CHECKOUT_PATH }}

--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
+          node-version: ${{ vars.DEFAULT_NODE_VERSION }}
           pnpm-install-args: --lockfile-only
 
       - name: Commit and push if changed

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -10,6 +10,8 @@
 #     runs-on: ubuntu-latest
 #     steps:
 #       - uses: sap/ai-sdk-js/.github/actions/setup@main
+#         with:
+#           node-version: ${{ vars.DEFAULT_NODE_VERSION }}
 #       - name: Get Changelog
 #         uses: sap/cloud-sdk-js/.github/actions/get-changelog@main
 #         id: get-changelog

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: sap/ai-sdk-js/.github/actions/setup@main
+        with:
+          node-version: ${{ vars.DEFAULT_NODE_VERSION }}
       - name: Create .env file
         env:
           AICORE_SERVICE_KEY: ${{ secrets[matrix.secret-name] }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: sap/ai-sdk-js/.github/actions/setup@main
         with:
+          node-version: ${{ vars.DEFAULT_NODE_VERSION }}
           pnpm-install-args: ''
 
       - name: prepare canary changeset

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@
 
 # env:
 #   DOCS_REPO: SAP/ai-sdk
-#   NODE_VERSION: ${{ vars.DEFAULT_NODE_VERSION }}
 
 # jobs:
 #   check-release-notes-pr:
@@ -19,7 +18,7 @@
 #     steps:
 #       - uses: sap/ai-sdk-js/.github/actions/setup@main
 #         with:
-#           node-version: ${{ env.NODE_VERSION }}
+#           node-version: ${{ vars.DEFAULT_NODE_VERSION }}
 #       - name: Determine Docs PR Branch Name
 #         id: determine-branch-name
 #         run: |
@@ -62,7 +61,7 @@
 #     steps:
 #       - uses: sap/ai-sdk-js/.github/actions/setup@main
 #         with:
-#           node-version: ${{ env.NODE_VERSION }}
+#           node-version: ${{ vars.DEFAULT_NODE_VERSION }}
 #       - name: publish
 #         run: |
 #           pnpm changeset publish

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: sap/ai-sdk-js/.github/actions/setup@main
+        with:
+          node-version: ${{ vars.DEFAULT_NODE_VERSION }}
       - run: pnpm smoke-tests create-deployment
       - uses: vchrisb/setup-cf@5aa69781ba95297cea2b80e71926198bed38ef5e
         with:


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

- [ ] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- [ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2
- [ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.

## What this PR does and why it is needed

[Reusable flow `setup` fails](https://github.com/SAP/ai-sdk-js/actions/runs/17546129492/job/49827913432) due to using `vars` in input's `default` property.

Fix by reading `vars` in individual workflow and provide the value over `node-version` input property to the reusable workflow.
