### PR TITLE
chore: Fix type text deploymentId

### DIFF
--- a/tests/type-tests/test/orchestration.test-d.ts
+++ b/tests/type-tests/test/orchestration.test-d.ts
@@ -50,7 +50,7 @@ expectType<Promise<OrchestrationResponse>>(
         }
       }
     },
-    { deploymentId: 'deploymentId' } as any
+    { deploymentId: 'deploymentId' }
   ).chatCompletion()
 );
 


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#148.

- [ ] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- [ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2
- [ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.

## What this PR does and why it is needed

Remove `as any` in type test of deployment ID
