### PR TITLE
chore: Test for an error

### DIFF
--- a/packages/orchestration/src/orchestration-client.test.ts
+++ b/packages/orchestration/src/orchestration-client.test.ts
@@ -900,6 +900,26 @@ describe('orchestration service client', () => {
     `);
   });
   describe('OrchestrationClient Stream Error Handling', () => {
+    it('should throw an error when streaming with invalid JSON configuration', async () => {
+      const invalidJsonConfig = JSON.stringify({
+        config: {
+          stream: { enabled: true },
+          modules: {
+            prompt_templating: {
+              model: {
+                name: 'gpt-4o',
+                params: { version: 4.9 }
+              }
+            }
+          }
+        }
+      });
+
+      const client = new OrchestrationClient(invalidJsonConfig);
+
+      await expect(client.stream()).rejects.toThrow('Invalid JSON configuration');
+    });
+
     it('should abort controller and re-throw error when network request fails', async () => {
       const config: OrchestrationModuleConfig = {
         promptTemplating: {


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#302.

- [ ] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- [ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2
- [ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.

## What this PR does and why it is needed

Test for checking the orchestration error response structure.
