### PR TITLE
chore: Disable canary release job until v2 release

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,8 +1,6 @@
 name: publish-canary
 
 on:
-  schedule:
-    - cron: '0 1 * * *'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Disabling canary release job until v2 releases.