### PR TITLE
chore: Adjust masking type

### DIFF
--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -120,13 +120,13 @@ export interface FilteringModule {
 /**
  * Representation of the `MaskingModuleConfig` schema.
  */
-export interface MaskingModule {
+export type MaskingModule = {
   /**
    * List of masking service providers
    * Min Items: 1.
    */
   masking_providers: MaskingProviderConfig[];
-}
+};
 
 /**
  * Configuration for translation module.


### PR DESCRIPTION
## Context

This change avoids a future potential breaking change when orchestration changes the masking module config by adding a discriminator.

- [ ] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- [ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2
- [ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
