### PR TITLE
chore: Revert "Update publish-canary.yml (#1096)"

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,6 +1,8 @@
 name: publish-canary
 
 on:
+  schedule:
+    - cron: '0 1 * * *'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
This reverts commit 4722ec0ac09350636e4a90d13ba9fcd59584cf64.

## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

- [x] I know which base branch I chose for this PR, as the default branch is `main` now, and is for v2 development.
- ~[ ] I've updated (v2-Upgrade-Guide.md)[./v2-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v2~
- ~[ ] I have created a PR for `v1-main`, if my changes need to be backported to v1.~

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
