### PR TITLE
fix: JSDoc example of `buildAzureContentSafetyFilter()` function

### DIFF
--- a/.changeset/empty-wasps-lick.md
+++ b/.changeset/empty-wasps-lick.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/orchestration': patch
+---
+
+[Fixed Issue] Fix JSDoc example of `buildAzureContentSafetyFilter()` function.

--- a/packages/orchestration/src/util/filtering.ts
+++ b/packages/orchestration/src/util/filtering.ts
@@ -19,7 +19,7 @@ import type {
  * @param config - Configuration for Azure content safety filter.
  * If skipped, the default configuration of `ALLOW_SAFE_LOW` is used for all filter categories.
  * @returns Azure content safety configuration.
- * @example "buildAzureContentSafetyFilter({ type: 'input', hate: 'ALLOW_SAFE', violence: 'ALLOW_SAFE_LOW_MEDIUM' })"
+ * @example "buildAzureContentSafetyFilter('input', { hate: 'ALLOW_SAFE', violence: 'ALLOW_SAFE_LOW_MEDIUM' })"
  */
 export function buildAzureContentSafetyFilter<T extends ConfigType>(
   type: T,

--- a/styles/config/vocabularies/SAP/accept.txt
+++ b/styles/config/vocabularies/SAP/accept.txt
@@ -141,3 +141,5 @@ CDS
 
 [Ll][Ll][Mm]'s
 [Ll][Ll][Mm]s
+
+JSDoc


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

## What this PR does and why it is needed

Unfortunately, the JSDoc of this function was overlooked and was not changed to the correct usage.