### PR TITLE
fix: Support AI core service key changes at runtime

### DIFF
--- a/.changeset/loose-banks-itch.md
+++ b/.changeset/loose-banks-itch.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/core': patch
+---
+
+Support AI core service key changes at runtime

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -1,13 +1,36 @@
 import nock from 'nock';
 import { mockClientCredentialsGrantCall } from '../../../test-util/mock-http.js';
+import { dummyToken } from '../../../test-util/mock-jwt.js';
 import { getAiCoreDestination } from './context.js';
 
 describe('context', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset environment variables before each test
+    process.env = { ...originalEnv };
+    delete process.env.AICORE_SERVICE_KEY;
+
+    // Clean all nock interceptors
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
   afterAll(() => {
     nock.cleanAll();
   });
 
   it('should throw if client credentials are not fetched', async () => {
+    // Clean up any existing mocks first
+    nock.cleanAll();
+
+    // Don't set environment variable so it falls back to service binding
+    delete process.env.AICORE_SERVICE_KEY;
+
+    // Mock the authentication to return an error
     mockClientCredentialsGrantCall(
       {
         error: 'unauthorized',
@@ -15,8 +38,85 @@ describe('context', () => {
       },
       401
     );
+
     await expect(getAiCoreDestination()).rejects.toThrow(
       /Could not fetch client credentials token for service of type "aicore"/
     );
+  });
+
+  describe('getAiCoreDestination with environment variable', () => {
+    it('should use environment variable when present', async () => {
+      const mockServiceKey = {
+        clientid: 'clientid',
+        clientsecret: 'clientsecret',
+        url: 'https://example.authentication.eu12.hana.ondemand.com',
+        identityzone: 'examplezone',
+        identityzoneid: 'examplezoneid',
+        appname: 'appname',
+        serviceurls: {
+          AI_API_URL: 'https://api.ai.ml.hana.ondemand.com'
+        }
+      };
+
+      process.env.AICORE_SERVICE_KEY = JSON.stringify(mockServiceKey);
+
+      mockClientCredentialsGrantCall({
+        access_token: dummyToken,
+        token_type: 'Bearer',
+        expires_in: 3600
+      });
+
+      const result = await getAiCoreDestination();
+
+      expect(result).toBeDefined();
+      expect(result.url).toBe('https://api.ai.ml.hana.ondemand.com');
+    });
+
+    it('should verify environment variable is checked every time', async () => {
+      const mockServiceKey = {
+        clientid: 'clientid',
+        clientsecret: 'clientsecret',
+        url: 'https://example.authentication.eu12.hana.ondemand.com',
+        identityzone: 'examplezone',
+        identityzoneid: 'examplezoneid',
+        appname: 'appname',
+        serviceurls: {
+          AI_API_URL: 'https://api.ai.ml.hana.ondemand.com'
+        }
+      };
+
+      // First call without environment variable should use service binding
+      delete process.env.AICORE_SERVICE_KEY;
+
+      // Set environment variable for subsequent calls
+      process.env.AICORE_SERVICE_KEY = JSON.stringify(mockServiceKey);
+
+      mockClientCredentialsGrantCall({
+        access_token: dummyToken,
+        token_type: 'Bearer',
+        expires_in: 3600
+      });
+
+      const result = await getAiCoreDestination();
+
+      expect(result).toBeDefined();
+      expect(result.url).toBe('https://api.ai.ml.hana.ondemand.com');
+    });
+
+    it('should handle empty environment variable correctly', async () => {
+      process.env.AICORE_SERVICE_KEY = '';
+
+      mockClientCredentialsGrantCall({
+        access_token: dummyToken,
+        token_type: 'Bearer',
+        expires_in: 3600
+      });
+
+      const result = await getAiCoreDestination();
+
+      // Empty string should fallback to service binding, which should work with proper mocking
+      expect(result).toBeDefined();
+      expect(result.url).toBe('https://api.ai.ml.hana.ondemand.com');
+    });
   });
 });

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -16,6 +16,7 @@ describe('context', () => {
   });
 
   afterEach(() => {
+    nock.cleanAll();
     process.env = originalEnv;
   });
 
@@ -24,12 +25,6 @@ describe('context', () => {
   });
 
   it('should throw if client credentials are not fetched', async () => {
-    // Clean up any existing mocks first
-    nock.cleanAll();
-
-    // Don't set environment variable so it falls back to service binding
-    delete process.env.AICORE_SERVICE_KEY;
-
     // Mock the authentication to return an error
     mockClientCredentialsGrantCall(
       {

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -7,6 +7,7 @@ describe('context', () => {
   afterAll(() => {
     nock.cleanAll();
   });
+
   it('should throw if client credentials are not fetched', async () => {
     mockClientCredentialsGrantCall(
       {

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -17,8 +17,6 @@ const logger = createLogger({
   messageContext: 'context'
 });
 
-let aiCoreServiceBinding: Service | undefined;
-
 /**
  * Returns a destination object.
  * @param destination - The destination to use for the request.
@@ -45,20 +43,12 @@ export async function getAiCoreDestination(
     return resolvedDestination;
   }
 
-  const aiCoreEnv = getAiCoreServiceKeyFromEnv();
-  if (aiCoreEnv) {
-    // Environment variable exists - use it directly
-    aiCoreServiceBinding = aiCoreEnv;
-  }
-
-  // No environment variable - use cached service binding or fetch it
+  // Get service binding from environment variable or service binding
+  const aiCoreServiceBinding = getAiCoreServiceKeyFromEnv() || getServiceBinding('aicore');
   if (!aiCoreServiceBinding) {
-    aiCoreServiceBinding = getServiceBinding('aicore');
-    if (!aiCoreServiceBinding) {
-      throw new Error(
-        'Could not find service credentials for AI Core. Please check the service binding.'
-      );
-    }
+    throw new Error(
+      'Could not find service credentials for AI Core. Please check the service binding.'
+    );
   }
 
   const aiCoreDestination = (await transformServiceBindingToDestination(

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -45,10 +45,15 @@ export async function getAiCoreDestination(
     return resolvedDestination;
   }
 
-  // Otherwise, get the destination from env or service binding with default service name "aicore".
+  const aiCoreEnv = getAiCoreServiceKeyFromEnv();
+  if (aiCoreEnv) {
+    // Environment variable exists - use it directly
+    aiCoreServiceBinding = aiCoreEnv;
+  }
+
+  // No environment variable - use cached service binding or fetch it
   if (!aiCoreServiceBinding) {
-    aiCoreServiceBinding =
-      getAiCoreServiceKeyFromEnv() || getServiceBinding('aicore');
+    aiCoreServiceBinding = getServiceBinding('aicore');
     if (!aiCoreServiceBinding) {
       throw new Error(
         'Could not find service credentials for AI Core. Please check the service binding.'

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -44,7 +44,8 @@ export async function getAiCoreDestination(
   }
 
   // Get service binding from environment variable or service binding
-  const aiCoreServiceBinding = getAiCoreServiceKeyFromEnv() || getServiceBinding('aicore');
+  const aiCoreServiceBinding =
+    getAiCoreServiceKeyFromEnv() || getServiceBinding('aicore');
   if (!aiCoreServiceBinding) {
     throw new Error(
       'Could not find service credentials for AI Core. Please check the service binding.'


### PR DESCRIPTION
## Context
Closes #1150

## What this PR does and why it is needed
This PR removes the global variable aiCoreServiceBinding (previously used as a cache) in order to support runtime changes of the service key.  

The cache added unnecessary complexity and prevented updates when environment variables changed at runtime. Since there are no costly API calls involved, the performance impact of removing the cache is negligible, while improving flexibility and correctness.
