### PR TITLE
chore: Use `zod/v3` in Agent tutorial and add plain LangChain MCP sample code

### DIFF
--- a/sample-code/src/langchain-orchestration.ts
+++ b/sample-code/src/langchain-orchestration.ts
@@ -1,5 +1,5 @@
 import { StringOutputParser } from '@langchain/core/output_parsers';
-import { AzureOpenAiChatClient, OrchestrationClient } from '@sap-ai-sdk/langchain';
+import { OrchestrationClient } from '@sap-ai-sdk/langchain';
 import {
   buildAzureContentSafetyFilter,
   buildDpiMaskingProvider,
@@ -21,6 +21,7 @@ import {
 } from '@langchain/core/messages';
 // eslint-disable-next-line import/no-internal-modules
 import * as z from 'zod/v4';
+// eslint-disable-next-line import/no-internal-modules
 import { getMcpTools } from './tutorials/mcp/mcp-adapter.js';
 import type { BaseMessage, AIMessageChunk } from '@langchain/core/messages';
 import type { LangChainOrchestrationModuleConfig } from '@sap-ai-sdk/langchain';
@@ -343,13 +344,16 @@ export async function invokeToolChain(): Promise<string> {
  * @returns LLM response.
  */
 export async function invokeMcpToolChain(): Promise<string> {
-  const client = new OrchestrationClient({
-    promptTemplating: {
-      model: {
-        name: 'gpt-4o'
+  const client = new OrchestrationClient(
+    {
+      promptTemplating: {
+        model: {
+          name: 'gpt-4o'
+        }
       }
-    }
-  }, { maxRetries: 0 });
+    },
+    { maxRetries: 0 }
+  );
 
   const tools = [...getMcpTools];
 
@@ -385,4 +389,4 @@ export async function invokeMcpToolChain(): Promise<string> {
 
   // parse the response
   return parser.invoke(finalResponse);
-};
+}

--- a/sample-code/src/server.ts
+++ b/sample-code/src/server.ts
@@ -57,7 +57,8 @@ import {
   invokeLangGraphChain as invokeLangGraphChainOrchestration,
   invokeChainWithMasking,
   invokeToolChain as invokeToolChainOrchestration,
-  streamChain as streamChainOrchestration
+  streamChain as streamChainOrchestration,
+  invokeMcpToolChain
 } from './langchain-orchestration.js';
 import {
   createCollection,
@@ -484,6 +485,14 @@ app.get('/langchain/invoke-rag-chain', async (req, res) => {
 app.get('/langchain/invoke-tool-chain', async (req, res) => {
   try {
     res.header('Content-Type', 'text/plain').send(await invokeToolChain());
+  } catch (error: any) {
+    sendError(res, error);
+  }
+});
+
+app.get('/langchain/invoke-mcp-tool-chain', async (req, res) => {
+  try {
+    res.header('Content-Type', 'text/plain').send(await invokeMcpToolChain());
   } catch (error: any) {
     sendError(res, error);
   }

--- a/sample-code/src/server.ts
+++ b/sample-code/src/server.ts
@@ -58,7 +58,7 @@ import {
   invokeChainWithMasking,
   invokeToolChain as invokeToolChainOrchestration,
   streamChain as streamChainOrchestration,
-  invokeMcpToolChain
+  invokeMcpToolChain as invokeMcpToolChainOrchestration
 } from './langchain-orchestration.js';
 import {
   createCollection,
@@ -492,7 +492,9 @@ app.get('/langchain/invoke-tool-chain', async (req, res) => {
 
 app.get('/langchain/invoke-mcp-tool-chain', async (req, res) => {
   try {
-    res.header('Content-Type', 'text/plain').send(await invokeMcpToolChain());
+    res
+      .header('Content-Type', 'text/plain')
+      .send(await invokeMcpToolChainOrchestration());
   } catch (error: any) {
     sendError(res, error);
   }

--- a/sample-code/src/tutorials/mcp/weather-mcp-server.ts
+++ b/sample-code/src/tutorials/mcp/weather-mcp-server.ts
@@ -3,7 +3,7 @@
 /* eslint-disable import/no-internal-modules */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import * as z from 'zod/v4';
+import * as z from 'zod/v3';
 
 const server = new McpServer({
   name: 'Open-Meteo Weather MCP Server',
@@ -16,7 +16,7 @@ server.tool(
   {
     city: z
       .string()
-      .meta({ description: 'The name of the city to get the weather for' })
+      .describe('The name of the city to get the weather for')
   },
   async ({ city }) => {
     try {

--- a/sample-code/src/tutorials/mcp/weather-mcp-server.ts
+++ b/sample-code/src/tutorials/mcp/weather-mcp-server.ts
@@ -14,9 +14,7 @@ server.tool(
   'get_weather',
   'Tool to fetch weather details for a specific city',
   {
-    city: z
-      .string()
-      .describe('The name of the city to get the weather for')
+    city: z.string().describe('The name of the city to get the weather for')
   },
   async ({ city }) => {
     try {


### PR DESCRIPTION
## Context

Relates to SAP/ai-sdk-js#1145.

Relates to SAP/ai-sdk-js-backlog#374

## What this PR does and why it is needed

The first part is about switching from using `zod/v4` to `zod/v3` with `zod@3.x` package in `sample-code/src/tutorials/mcp/weather-mcp-server.ts` since `@modelcontextprotocol/sdk` does not even support `zod/v4` from `zod@3.x` due to the outdated zod dependency.

`modelcontextprotocol` typescript sdk is working on supporting `zod@4.x` package directly. See https://github.com/modelcontextprotocol/typescript-sdk/pull/869.

The second part is to add a new sample-code show-casing how to use LangChain's MCP adapter with pure LangChain `bindTools()` without LangGraph. (as requested in SAP/ai-sdk-js#1145).