### PR TITLE
chore: Fix e2e caused by `getMcpTools` await

### DIFF
--- a/sample-code/src/langchain-orchestration.ts
+++ b/sample-code/src/langchain-orchestration.ts
@@ -22,7 +22,7 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import * as z from 'zod/v4';
 // eslint-disable-next-line import/no-internal-modules
-import { getMcpTools } from './tutorials/mcp/mcp-adapter.js';
+import { mcpClient } from './tutorials/mcp/mcp-adapter.js';
 import type { BaseMessage, AIMessageChunk } from '@langchain/core/messages';
 import type { LangChainOrchestrationModuleConfig } from '@sap-ai-sdk/langchain';
 
@@ -355,7 +355,7 @@ export async function invokeMcpToolChain(): Promise<string> {
     { maxRetries: 0 }
   );
 
-  const tools = [...getMcpTools];
+  const tools = await mcpClient.getTools();
 
   const messages: BaseMessage[] = [
     new HumanMessage('What is the weather like in Berlin?')

--- a/sample-code/src/tutorials/mcp/mcp-adapter.ts
+++ b/sample-code/src/tutorials/mcp/mcp-adapter.ts
@@ -2,8 +2,10 @@
 
 import { MultiServerMCPClient } from '@langchain/mcp-adapters';
 
-// Create client and connect to server
-const client = new MultiServerMCPClient({
+/**
+ * Client to connect to multiple MCP servers.
+ */
+export const mcpClient = new MultiServerMCPClient({
   throwOnLoadError: true,
   prefixToolNameWithServerName: false,
   additionalToolNamePrefix: '',
@@ -15,9 +17,3 @@ const client = new MultiServerMCPClient({
     }
   }
 });
-
-/**
- * Fetches tools from the MCP server.
- * @returns An array of tools for fetching weather data.
- */
-export const getMcpTools = await client.getTools();

--- a/sample-code/src/tutorials/travel-itinerary-agent.ts
+++ b/sample-code/src/tutorials/travel-itinerary-agent.ts
@@ -15,7 +15,7 @@ import { AzureOpenAiChatClient } from '@sap-ai-sdk/langchain';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { tool } from '@langchain/core/tools';
 import * as z from 'zod/v4';
-import { getMcpTools } from './mcp/mcp-adapter.js';
+import { mcpClient } from './mcp/mcp-adapter.js';
 import type { AIMessage } from '@langchain/core/messages';
 /**
  * This example demonstrates how to create a travel itinerary assistant using LangGraph and MCP.
@@ -44,7 +44,7 @@ const getRestaurantsTool = tool(
 );
 
 // Define the tools for the agent to use
-const tools = [...getMcpTools, getRestaurantsTool];
+const tools = [...(await mcpClient.getTools()), getRestaurantsTool];
 const toolNode = new ToolNode(tools);
 
 // Create a model


### PR DESCRIPTION
Whenever a file import `getMcpTools()` function, which awaits `client.getTools()`, this file needs the mcp server to run, no matter the function is actually used.

I removed this function and export the mcp client instead.