### PR TITLE
chore: Refactor bump workflow permissions

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -15,12 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.bump.outputs.version }}
-    permissions:
-      checks: write
-      contents: write
     steps:
       - uses: sap/ai-sdk-js/.github/actions/setup@main
         with:
+          token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
           ref: 'main'
           node-version: ${{ vars.DEFAULT_NODE_VERSION }}
       - name: bump version


### PR DESCRIPTION
We removed the admin token in the commit-and-tag step. However the GITHUB_TOKEN doesn't have sufficient rights to bypass certain checks (merge to main without creating a PR).
 Reverting this to test bump.


## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
