### PR TITLE
ci: Avoid auto-merge for major updates from dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,11 +68,13 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Approve a PR
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#412.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
The Dependabot workflow mergers PRs regardless of the update type, including major updates which may require additional review such as the recent langchain update.

This is achieved by ensuring that the update type is not `version-update:semver-major`.
