### PR TITLE
chore(dependabot/v1-main): Avoid langchain v1 upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,11 @@ updates:
       # We only want to do major node updates on purpose, so don't create dependabot PRs for major versions
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
+      # Avoid langchain-v1 release for sdk v1-main
+      - dependency-name: 'langchain'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@langchain/*'
+        update-types: ['version-update:semver-major']
     groups:
       sap-cloud-sdk:
         patterns: ['@sap-cloud-sdk/*']


### PR DESCRIPTION
## Context

#1211 changes to the dependabot config did not handle update to v1-main.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
