### PR TITLE
chore: Add sample-code/e2e-test for scoped prompt-template refs

### DIFF
--- a/sample-code/src/index.ts
+++ b/sample-code/src/index.ts
@@ -10,6 +10,7 @@ export {
   orchestrationChatCompletion,
   orchestrationTemplating,
   orchestrationPromptRegistry,
+  orchestrationCompletionPromptRegistryScoped,
   orchestrationInputFiltering,
   orchestrationOutputFiltering,
   orchestrationRequestConfig,

--- a/sample-code/src/orchestration.ts
+++ b/sample-code/src/orchestration.ts
@@ -206,6 +206,39 @@ export async function orchestrationPromptRegistry(): Promise<OrchestrationRespon
 }
 
 /**
+ * Use a template stored in the prompt registry store at
+ * the resource group scope.
+ * @returns The orchestration service response.
+ */
+export async function orchestrationCompletionPromptRegistryScoped(): Promise<OrchestrationResponse> {
+  const orchestrationClient = new OrchestrationClient(
+    {
+      promptTemplating: {
+        prompt: {
+          // refer to a prompt template stored at resource group scope
+          template_ref: {
+            name: 'e2e-test-scoped',
+            scenario: 'e2e-test-scoped',
+            version: '0.0.1',
+            scope: 'resource_group'
+          }
+        },
+        // define the language model to be used
+        model: {
+          name: 'gpt-4o'
+        }
+      }
+    },
+    // provide resource group where the template is stored
+    { resourceGroup: 'ai-sdk-js-e2e' }
+  );
+
+  return orchestrationClient.chatCompletion({
+    placeholderValues: { country: 'France' }
+  });
+}
+
+/**
  * Apply multiple content filters to the input.
  * @returns The orchestration service error response.
  */

--- a/tests/e2e-tests/src/orchestration.test.ts
+++ b/tests/e2e-tests/src/orchestration.test.ts
@@ -2,6 +2,7 @@ import {
   orchestrationChatCompletion,
   orchestrationTemplating,
   orchestrationPromptRegistry,
+  orchestrationCompletionPromptRegistryScoped,
   orchestrationInputFiltering,
   orchestrationOutputFiltering,
   orchestrationRequestConfig,
@@ -48,6 +49,12 @@ describe('orchestration', () => {
 
   it('should complete a chat with a template reference', async () => {
     const response = await orchestrationPromptRegistry();
+
+    assertContent(response);
+  });
+
+  it('should complete a chat with a scoped template reference', async () => {
+    const response = await orchestrationCompletionPromptRegistryScoped();
 
     assertContent(response);
   });


### PR DESCRIPTION
## Context

Related SAP/ai-sdk-js-backlog#429.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
Types for this were added in the recent orchestration spec upgrade, but sample-code and an e2e tests were still missing.
