### PR TITLE
chore: Limit peer dependency range

### DIFF
--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -43,6 +43,6 @@
     "@langchain/langgraph": "^1.0.7"
   },
   "peerDependencies": {
-    "@langchain/core": "^1.1.8"
+    "@langchain/core": ">=1.0.0 || <=1.1.8"
   }
 }


### PR DESCRIPTION
## Context

Limits the langchain peer dependency to versions between 1.0.0 and 1.1.8. 
We should make a new release without limitations once this is merged: https://github.com/langchain-ai/langchainjs/pull/9781

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
