### PR TITLE
chore: Improve test coverage on `OrchestrationStreamResponse`

### DIFF
--- a/packages/orchestration/src/orchestration-stream-response.test.ts
+++ b/packages/orchestration/src/orchestration-stream-response.test.ts
@@ -111,15 +111,13 @@ describe('OrchestrationStreamResponse', () => {
   });
 
   describe('getFinishReason', () => {
-    it('should return finish reason for default index', () => {
-      closeStream();
+    beforeEach(closeStream);
 
+    it('should return finish reason for default index', () => {
       expect(streamResponse.getFinishReason()).toBe('stop');
     });
 
     it('should return undefined for non-existent choice index', () => {
-      closeStream();
-
       expect(streamResponse.getFinishReason(1)).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
#1464 expanded test coverage of `OrchestrationStreamResponse` (did not have dedicated tests). This PR splits these changes into a separate PR.
