### PR TITLE
chore: Fix pnpm-lockfile refresh merge condition handling

### DIFF
--- a/.github/workflows/pnpm-update.yml
+++ b/.github/workflows/pnpm-update.yml
@@ -106,6 +106,7 @@ jobs:
 
                 if (!allAcceptable) {
                   console.log(`PR #${pr.number} has failed checks that prevent merging.`);
+                  return 'failed-checks';
                 }
 
                 return 'success';


### PR DESCRIPTION
## Context

https://github.com/SAP/ai-sdk-js/pull/1490

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->
#1490 was merged despite CI failing. This PR tries to avoid this for the future by only checking the CI status after 2 minutes to make sure that relevant CI jobs have started.
