### PR TITLE
chore: Harden pnpm-lock update action

### DIFF
--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   update-lockfile:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
 
     steps:
       - name: Setup Environment


### PR DESCRIPTION
> This is not a security vulnerability, it is just a change that adds further protection.

## What this PR does and why it is needed

The current implementation of the action that updates the pnpm-lock.yaml only checks github.actor. This can potentially be abused by using Dependabot in a fork, invoking a pull request with elevated permissions.

However, this can not actually be abused by an attacker, because it checks out "github.head_ref", which  is always branch name and even a "malicious" head_ref could only reference a branch in this repository (not in a fork).

Still, this change provides additional protection against malicious actors triggering the workflow.

More details about this type of issue are available at https://www.synacktiv.com/publications/github-actions-exploitation-dependabot.