### PR TITLE
chore: Fix e2e-test by using updated configuration ID

### DIFF
--- a/tests/e2e-tests/src/utils/ai-api-utils.ts
+++ b/tests/e2e-tests/src/utils/ai-api-utils.ts
@@ -10,7 +10,7 @@ export const resourceGroup = 'ai-sdk-js-e2e';
 /**
  * @internal
  */
-export const configurationId = '54cc966d-8bc1-44ab-a9dc-658d59ef205d';
+export const configurationId = '81329471-f856-4f22-b274-0dcbd831b3a8';
 
 /**
  * @internal


### PR DESCRIPTION
# Update E2E Test Configuration for AI API

🔧 **Chore**: Updated the AI API configuration ID in end-to-end tests to use a deployment with an active model instead of a retired one.

## Changes

* `tests/e2e-tests/src/utils/ai-api-utils.ts`: Replaced the outdated configuration ID (`54cc966d-8bc1-44ab-a9dc-658d59ef205d`) with a new one (`81329471-f856-4f22-b274-0dcbd831b3a8`) that references an active model deployment.

## Context

The previous configuration was referencing a retired model, causing E2E test failures. This update ensures tests run against a currently supported model deployment.

**E2E Test Run**: [View Results](https://github.com/SAP/ai-sdk-js/actions/runs/21672086221/job/62482325022)

- [ ] 🔄 Regenerate and Update Summary

