### PR TITLE
chore: Use `Pick` for 'signal' type in CustomRequestConfig

### DIFF
--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -29,7 +29,8 @@ export type CustomRequestConfig = Pick<
   | 'httpsAgent'
   | 'parameterEncoder'
   | 'signal'
-> & Record<string, any>;
+> &
+  Record<string, any>;
 
 /**
  * The options to call an endpoint.


### PR DESCRIPTION
# Use `Pick` for 'signal' type in CustomRequestConfig

### Changes

♻️ **Refactor**: Simplified type definition for `CustomRequestConfig` by removing a workaround and incorporating 'signal' into the `Pick` utility type.

### Changes

* `packages/core/src/http-client.ts`: Replaced the temporary workaround for the `signal` property with a proper `Pick` type inclusion. The `AbortSignal` type is now extracted directly from `HttpRequestConfig` instead of being manually defined, cleaning up the type definition and removing the TODO comment.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.17.80` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Event Trigger: `issue_comment.edited`
- Correlation ID: `cc545f00-13f6-11f1-97ea-658feb597d3a`
</details>
