### PR TITLE
chore: Remove type for gemini embedding model

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,6 @@ export type {
   AzureOpenAiChatModel,
   AzureOpenAiEmbeddingModel,
   GcpVertexAiChatModel,
-  GcpVertexAiEmbeddingModel,
   AwsBedrockChatModel,
   AiCoreOpenSourceChatModel,
   AiCoreOpenSourceEmbeddingModel,

--- a/packages/core/src/model-types.ts
+++ b/packages/core/src/model-types.ts
@@ -32,11 +32,6 @@ export type GcpVertexAiChatModel = LiteralUnion<
 >;
 
 /**
- * GCP Vertex AI models for embedding.
- */
-export type GcpVertexAiEmbeddingModel = LiteralUnion<'gemini-embedding'>;
-
-/**
  * AWS Bedrock models for chat completion.
  */
 export type AwsBedrockChatModel = LiteralUnion<


### PR DESCRIPTION
## Context

Remove the type introduced for gemini embedding model, as it is not currently supported by orchestration service.
So, the type is currently unused. Refer [Note](https://me.sap.com/notes/3437766)