### PR TITLE
chore(spec-update): Ensure git commit does not fail if there are no changes

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -178,7 +178,7 @@ jobs:
         run: |
           git add --all
           git status
-          git commit -m "Update $SERVICE based on $REF"
+          git commit -m "Update $SERVICE based on $REF" || true
           git push --set-upstream origin "$BRANCH"
 
       - name: 'Create PR'


### PR DESCRIPTION
# Fix: Prevent `git commit` Failure When No Changes Exist in Spec Update Workflow

### Bug Fix

🐛 Resolved an issue in the spec update workflow where `git commit` would fail if there were no changes to commit, causing the workflow step to error out unnecessarily.

### Changes

* `.github/workflows/spec-update.yaml`: Appended `|| true` to the `git commit` command in the "Push changes" step, ensuring the step succeeds even when there are no staged changes to commit (e.g., when `git add --all` results in nothing new to commit).

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.19.9` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Event Trigger: `issue_comment.edited`
- Correlation ID: `ebe24200-2d0b-11f1-8e55-350b54d90b80`
</details>
