### PR TITLE
chore: Update Dependabot approval to use GH App

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,23 +59,31 @@ jobs:
     if: ${{ (github.actor == 'dependabot[bot]' || startsWith(github.event.pull_request.title, 'chore(deps')) && github.event_name == 'pull_request' }}
     needs: [test, checks]
     permissions:
-      pull-requests: write
-      contents: write
+      contents: read
     steps:
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Generate GitHub App token
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SAP_AI_SDK_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Approve a PR
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{steps.app-token.outputs.token}}
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{steps.app-token.outputs.token}}


### PR DESCRIPTION
## Context

Related #1690

The normal GitHub token can approve and trigger auto-merge, but the approval does not meet auto-merge conditions.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
