### PR TITLE
chore: Upgrade vulnerable dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,7 +406,7 @@ importers:
         version: 5.2.1
       hono:
         specifier: ^4.12.10
-        version: 4.12.10
+        version: 4.12.12
       langchain:
         specifier: ^1.3.0
         version: 1.3.0(@langchain/core@1.1.39(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
@@ -953,8 +953,8 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
-  '@hono/node-server@1.19.12':
-    resolution: {integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==}
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -1922,8 +1922,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   babel-jest@30.3.0:
     resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
@@ -2941,12 +2941,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.10:
-    resolution: {integrity: sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.12.9:
-    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -5521,9 +5517,9 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@1.19.12(hono@4.12.9)':
+  '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
-      hono: 4.12.9
+      hono: 4.12.12
 
   '@humanfs/core@0.19.1': {}
 
@@ -5883,7 +5879,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.12(hono@4.12.9)
+      '@hono/node-server': 1.19.13(hono@4.12.12)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -5893,7 +5889,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.9
+      hono: 4.12.12
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -6146,7 +6142,7 @@ snapshots:
       '@sap/xsenv': 6.1.0
       '@sap/xssec': 4.13.0
       async-retry: 1.3.3
-      axios: 1.14.0
+      axios: 1.15.0
       jks-js: 1.1.5
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
@@ -6194,7 +6190,7 @@ snapshots:
       '@sap-cloud-sdk/connectivity': 4.5.1
       '@sap-cloud-sdk/resilience': 4.5.1
       '@sap-cloud-sdk/util': 4.5.1
-      axios: 1.14.0
+      axios: 1.15.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -6220,7 +6216,7 @@ snapshots:
       '@sap-cloud-sdk/http-client': 4.5.1
       '@sap-cloud-sdk/resilience': 4.5.1
       '@sap-cloud-sdk/util': 4.5.1
-      axios: 1.14.0
+      axios: 1.15.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -6229,14 +6225,14 @@ snapshots:
     dependencies:
       '@sap-cloud-sdk/util': 4.5.1
       async-retry: 1.3.3
-      axios: 1.14.0
+      axios: 1.15.0
       opossum: 9.0.0
     transitivePeerDependencies:
       - debug
 
   '@sap-cloud-sdk/util@4.5.1':
     dependencies:
-      axios: 1.14.0
+      axios: 1.15.0
       chalk: 4.1.2
       logform: 2.7.0
       voca: 1.4.1
@@ -6254,7 +6250,7 @@ snapshots:
       '@sap/cds': 9.8.4(@eslint/js@9.39.4)
       '@sap/cds-mtxs': 3.8.1(@sap/cds@9.8.4(@eslint/js@9.39.4))(hdb@2.27.1)
       '@sap/hdi-deploy': 5.6.1(hdb@2.27.1)
-      axios: 1.14.0
+      axios: 1.15.0
       express: 5.2.1
       hdb: 2.27.1
       livereload-js: 4.0.2
@@ -6899,7 +6895,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.14.0:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
@@ -8121,9 +8117,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.10: {}
-
-  hono@4.12.9: {}
+  hono@4.12.12: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,9 +14,12 @@ packages:
   - tests/type-tests
 
 blockExoticSubdeps: true
-trustPolicy: no-downgrade
 minimumReleaseAge: 5760
 minimumReleaseAgeExclude:
   - '@sap-cloud-sdk/*'
   # Add minimum age exceptions for audit issues here
   # - sample-package@0.1.0
+  - axios@1.15.0
+  - hono@4.12.12
+  - '@hono/node-server@1.19.13'
+trustPolicy: no-downgrade


### PR DESCRIPTION
# Upgrade Vulnerable Dependencies

### Chore

🔧 Updated several vulnerable dependencies to their latest patched versions to address security vulnerabilities.

### Changes

* `pnpm-lock.yaml`: Updated lockfile to reflect upgraded dependency versions:
  - `axios`: `1.14.0` → `1.15.0` (across all `@sap-cloud-sdk/*` packages and `@sap/cds-dk`)
  - `hono`: `4.12.9` / `4.12.10` → `4.12.12`
  - `@hono/node-server`: `1.19.12` → `1.19.13`

* `pnpm-workspace.yaml`: Added `minimumReleaseAge` exceptions for the newly upgraded packages (`axios@1.15.0`, `hono@4.12.12`, `@hono/node-server@1.19.13`) to allow them to be used despite the minimum release age policy. Also fixed a minor whitespace/formatting issue and reordered the `trustPolicy` setting.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.11` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Correlation ID: `5fc70410-34b1-11f1-8394-253996ff31a7`
- Event Trigger: `issue_comment.edited`
</details>
