### PR TITLE
feat(orchestration): Exclude EmbeddingMultiFormat from public EmbeddingData type

### DIFF
--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -27,7 +27,8 @@ import type {
   EmbeddingsModelParams as OriginalEmbeddingsModelParams,
   SAPDocumentTranslationInput,
   SAPDocumentTranslationOutput,
-  Embedding
+  Embedding,
+  EmbeddingMultiFormat
 } from './client/api/schema/index.js';
 
 /**
@@ -848,7 +849,7 @@ export interface EmbeddingData {
   /**
    * The embedding vector, either as a number array, a base64-encoded string, or multiple formats in case multiple output formats were requested.
    */
-  embedding: Embedding;
+  embedding: Exclude<Embedding, EmbeddingMultiFormat>;
   /**
    * The index of the embedding in the list of embeddings.
    */


### PR DESCRIPTION
## Summary

- `EmbeddingMultiFormat` was added to the generated `Embedding` union but is not yet ready for public API exposure
- Temporarily excludes it from `EmbeddingData.embedding` via `Exclude<Embedding, EmbeddingMultiFormat>`
- Will be widened back to `Embedding` once multi-format support is fully tested

## Test plan

- [ ] No runtime changes — type-only modification verified by TypeScript compiler