### PR TITLE
feat(orchestration): Exclude EmbeddingMultiFormat from public EmbeddingData type

### DIFF
--- a/.changeset/nice-emus-train.md
+++ b/.changeset/nice-emus-train.md
@@ -2,4 +2,5 @@
 '@sap-ai-sdk/orchestration': minor
 ---
 
-[feat] Update orchestration specification to 0.115.19. Multiple embedding output formats are not yet supported in the orchestration embedding client.
+[feat] Update orchestration specification to 0.115.19. 
+Multiple embedding output formats are not yet supported in the orchestration embedding client.

--- a/.changeset/nice-emus-train.md
+++ b/.changeset/nice-emus-train.md
@@ -2,4 +2,4 @@
 '@sap-ai-sdk/orchestration': minor
 ---
 
-[feat] Update orchestration specification to 0.115.19
+[feat] Update orchestration specification to 0.115.19. Multiple embedding output formats are not yet supported in the orchestration embedding client.

--- a/packages/orchestration/src/orchestration-embedding-response.ts
+++ b/packages/orchestration/src/orchestration-embedding-response.ts
@@ -3,7 +3,9 @@ import type {
   EmbeddingsPostResponse,
   EmbeddingResult,
   EmbeddingsUsage,
-  ModuleResultsBase
+  ModuleResultsBase,
+  Embedding,
+  EmbeddingMultiFormat
 } from './client/api/schema/index.js';
 import type { EmbeddingData } from './orchestration-types.js';
 
@@ -23,7 +25,7 @@ export class OrchestrationEmbeddingResponse {
    */
   getEmbeddings(): EmbeddingData[] {
     return this._data.final_result.data.map((result: EmbeddingResult) => ({
-      embedding: result.embedding,
+      embedding: result.embedding as Exclude<Embedding, EmbeddingMultiFormat>,
       index: result.index,
       object: 'embedding'
     }));

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -28,7 +28,8 @@ import type {
   SAPDocumentTranslationInput,
   SAPDocumentTranslationOutput,
   Embedding,
-  EmbeddingMultiFormat
+  EmbeddingMultiFormat,
+  EncodingFormat
 } from './client/api/schema/index.js';
 
 /**
@@ -811,7 +812,9 @@ export type EmbeddingModelDetails = Omit<
 /**
  * Embedding model parameters.
  */
-export type EmbeddingModelParams = OriginalEmbeddingsModelParams;
+export type EmbeddingModelParams = Omit<OriginalEmbeddingsModelParams, 'encoding_format'> & {
+  encoding_format?: EncodingFormat;
+};
 
 /**
  * Embedding model configuration.

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -812,7 +812,10 @@ export type EmbeddingModelDetails = Omit<
 /**
  * Embedding model parameters.
  */
-export type EmbeddingModelParams = Omit<OriginalEmbeddingsModelParams, 'encoding_format'> & {
+export type EmbeddingModelParams = Omit<
+  OriginalEmbeddingsModelParams,
+  'encoding_format'
+> & {
   encoding_format?: EncodingFormat;
 };
 

--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -27,7 +27,8 @@ import type {
   EmbeddingsModelParams as OriginalEmbeddingsModelParams,
   SAPDocumentTranslationInput,
   SAPDocumentTranslationOutput,
-  Embedding
+  Embedding,
+  EmbeddingMultiFormat
 } from './client/api/schema/index.js';
 
 /**
@@ -848,7 +849,7 @@ export interface EmbeddingData {
   /**
    * The embedding vector, either as a number array, a base64-encoded string, or multiple formats in case multiple output formats were requested.
    */
-  embedding: Embedding;
+  embedding: Exclude<Embedding, EmbeddingMultiFormat>;
   /**
    * The index of the embedding in the list of embeddings.
    */


### PR DESCRIPTION
## Summary

Temporary fix until we try out how multi format responses with Embedding looks like.

- `EmbeddingMultiFormat` was added to the generated `Embedding` union but is not yet ready for public API exposure
- Temporarily excludes it from `EmbeddingData.embedding` via `Exclude<Embedding, EmbeddingMultiFormat>`
- Will be widened back to `Embedding` once multi-format support is fully tested

## Test plan

- [x] No runtime changes — type-only modification verified by TypeScript compiler