### PR TITLE
chore: Use `client-id` instead of `app-id`

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -29,19 +29,17 @@ jobs:
           MAJOR_VERSION=$(echo "$FULL_VERSION" | cut -d. -f1)
           echo "major-version=$MAJOR_VERSION" >> "$GITHUB_OUTPUT"
           echo "branch-name=docs/api-update-v${MAJOR_VERSION}-$(date +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"
-            
-      
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
+          client-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SAP_AI_SDK_BOT_PRIVATE_KEY }}
           owner: SAP
           repositories: ai-sdk
           permission-contents: write
           permission-pull-requests: write
-
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/auto-fix-lint.yml
+++ b/.github/workflows/auto-fix-lint.yml
@@ -14,7 +14,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
+          client-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SAP_AI_SDK_BOT_PRIVATE_KEY }}
           permission-contents: write
       - uses: sap/ai-sdk-js/.github/actions/setup@main

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
+          client-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SAP_AI_SDK_BOT_PRIVATE_KEY }}
           permission-contents: write
       - uses: sap/ai-sdk-js/.github/actions/setup@main
@@ -54,7 +54,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
+          client-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SAP_AI_SDK_BOT_PRIVATE_KEY }}
           owner: SAP
           repositories: ai-sdk
@@ -64,12 +64,12 @@ jobs:
         uses: sap/ai-sdk-js/.github/actions/setup@main
         with:
           node-version: ${{ vars.DEFAULT_NODE_VERSION }}
-      
+
       - name: Generate API documentation
         run: |
           pnpm generate
           pnpm doc
-      
+
       - name: Checkout Docs Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -81,17 +81,17 @@ jobs:
         id: update-notes
         run: |
           pnpm node --loader ts-node/esm -e "import { addCurrentChangelog } from './scripts/add-changelog.ts'; addCurrentChangelog()"
-      
+
       - name: Copy API documentation to docs repo
         run: |
           # Extract major version from full version (e.g., "2.8.0" -> "v2")
           FULL_VERSION="${{ needs.bump.outputs.version }}"
           MAJOR_VERSION=$(echo "$FULL_VERSION" | cut -d. -f1)
           VERSION="v${MAJOR_VERSION}"
-          
+
           # Copy generated docs to versioned folder
           rsync -avz --delete knowledge-base/api-reference/ "${{ env.DOCS_CHECKOUT_PATH }}/static/api/${VERSION}/"
-      
+
       - name: Open Release notes and API docs PR
         id: open_pr
         working-directory: ./ai-sdk-docs
@@ -104,11 +104,11 @@ jobs:
           git config --local user.name "$BOT_NAME"
           BRANCH_NAME="update-release-notes-js-${{ needs.bump.outputs.version }}"
           git checkout -b "${BRANCH_NAME}"
-          
+
           # Stage both release notes and API docs
           git add docs-js/release-notes.mdx
           git add static/api/
-          
+
           if git diff --staged --quiet; then
             echo "No changes to commit."
             # Output an empty pr_url if no changes

--- a/.github/workflows/dependabot-pnpm-lock.yml
+++ b/.github/workflows/dependabot-pnpm-lock.yml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
+          client-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SAP_AI_SDK_BOT_PRIVATE_KEY }}
           permission-contents: write
       - name: Setup Environment

--- a/.github/workflows/pnpm-update.yml
+++ b/.github/workflows/pnpm-update.yml
@@ -13,7 +13,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
+          client-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SAP_AI_SDK_BOT_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
+          client-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SAP_AI_SDK_BOT_PRIVATE_KEY }}
           owner: SAP
           repositories: ai-sdk
@@ -81,7 +81,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
+          client-id: ${{ secrets.SAP_AI_SDK_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SAP_AI_SDK_BOT_PRIVATE_KEY }}
           owner: SAP
           repositories: ai-sdk
@@ -93,4 +93,3 @@ jobs:
         run: |
           echo "Attempting to merge PR for branch: ${{ needs.check-docs-pr.outputs.docs_branch }}"
           gh pr merge --squash "${{ needs.check-docs-pr.outputs.docs_branch }}" --delete-branch --repo "${{ env.DOCS_REPO }}"
-    


### PR DESCRIPTION
## Context

`app-id` is deprecated.

Relates to SAP/ai-sdk-js-backlog#522.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
