### PR TITLE
fix: Ensure collection cleanup runs even when e2e assertion fails

### DIFF
--- a/tests/e2e-tests/src/document-grounding.test.ts
+++ b/tests/e2e-tests/src/document-grounding.test.ts
@@ -14,11 +14,14 @@ describe('document grounding', () => {
     const collectionId = await createCollection();
     const timestamp = Date.now();
     await createDocumentsWithTimestamp(collectionId, timestamp);
-    const result = await orchestrationGrounding(
-      'When was the last time SAP AI SDK JavaScript end to end test was executed? Return only the latest timestamp in milliseconds without any other text.'
-    );
-    expect(result.getContent()).toEqual(timestamp.toString());
-    await deleteCollection(collectionId);
+    try {
+      const result = await orchestrationGrounding(
+        'When was the last time SAP AI SDK JavaScript end to end test was executed? Return only the latest timestamp in milliseconds without any other text.'
+      );
+      expect(result.getContent()).toEqual(timestamp.toString());
+    } finally {
+      await deleteCollection(collectionId);
+    }
   });
 
   it('should get the result based on grounding context from `help.sap.com` data respository via orchestration API', async () => {


### PR DESCRIPTION
## Summary

- Wrap the orchestration grounding assertion in a `try/finally` so `deleteCollection` always runs, even when the assertion fails.

## Root cause

Without `try/finally`, a failing assertion skips `deleteCollection`, leaving stale documents in the vector store. On the next run the LLM retrieves the old (now-highest-timestamp) document from the previous failed run instead of the newly inserted one, causing an arbitrary pass/fail cycle.

## Test plan

- [x] Run the e2e test twice in a row to confirm cleanup happens regardless of assertion outcome