### PR TITLE
fix: Disallow providing both orchestration config ref and config object in orchestration client

### DIFF
--- a/.changeset/tired-seals-buy.md
+++ b/.changeset/tired-seals-buy.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/orchestration': patch
+---
+
+[Fixed Issue] Disallow providing both orchestration config reference and config object at the same time.

--- a/packages/orchestration/src/orchestration-client.ts
+++ b/packages/orchestration/src/orchestration-client.ts
@@ -16,6 +16,7 @@ import {
   isOrchestrationModuleConfigList,
   assertIsOrchestrationModuleConfigList
 } from './orchestration-types.js';
+import type { Xor } from '@sap-cloud-sdk/util';
 import type { TemplatingChatMessage } from './client/api/schema/index.js';
 import type {
   HttpResponse,
@@ -59,17 +60,18 @@ export class OrchestrationClient {
    */
   constructor(
     private config:
-      | OrchestrationModuleConfig
-      | OrchestrationModuleConfigList
       | string
-      | OrchestrationConfigRef,
+      | Xor<OrchestrationConfigRef, OrchestrationModuleConfig | OrchestrationModuleConfigList>,
     private deploymentConfig?: ResourceGroupConfig | DeploymentIdConfig,
     private destination?: HttpDestinationOrFetchOptions
   ) {
     if (typeof config === 'string') {
       this.validateJsonConfig(config);
-    } else if (Array.isArray(config)) {
+    } else if (isOrchestrationModuleConfigList(config)) {
       this.config = this.parseModuleConfigList(config);
+    } else if (Array.isArray(config)) {
+      // Array that failed isOrchestrationModuleConfigList validation - let assertion throw with proper error
+      assertIsOrchestrationModuleConfigList(config);
     } else if (!isConfigReference(config)) {
       this.config = this.parseTemplatingModule(config);
     }

--- a/packages/orchestration/src/orchestration-client.ts
+++ b/packages/orchestration/src/orchestration-client.ts
@@ -61,7 +61,10 @@ export class OrchestrationClient {
   constructor(
     private config:
       | string
-      | Xor<OrchestrationConfigRef, OrchestrationModuleConfig | OrchestrationModuleConfigList>,
+      | Xor<
+          OrchestrationConfigRef,
+          OrchestrationModuleConfig | OrchestrationModuleConfigList
+        >,
     private deploymentConfig?: ResourceGroupConfig | DeploymentIdConfig,
     private destination?: HttpDestinationOrFetchOptions
   ) {

--- a/packages/orchestration/src/orchestration-client.ts
+++ b/packages/orchestration/src/orchestration-client.ts
@@ -70,11 +70,9 @@ export class OrchestrationClient {
   ) {
     if (typeof config === 'string') {
       this.validateJsonConfig(config);
-    } else if (isOrchestrationModuleConfigList(config)) {
-      this.config = this.parseModuleConfigList(config);
     } else if (Array.isArray(config)) {
-      // Array that failed isOrchestrationModuleConfigList validation - let assertion throw with proper error
       assertIsOrchestrationModuleConfigList(config);
+      this.config = this.parseModuleConfigList(config);
     } else if (!isConfigReference(config)) {
       this.config = this.parseTemplatingModule(config);
     }

--- a/tests/type-tests/test/orchestration.test-d.ts
+++ b/tests/type-tests/test/orchestration.test-d.ts
@@ -642,6 +642,21 @@ expectType<Promise<OrchestrationResponse>>(
   })
 );
 
+expectError(
+  new OrchestrationClient({
+    id: 'test-config-id',
+    promptTemplating: {
+      model: { name: 'gpt-5-mini' },
+      prompt: { template: [{ role: 'user', content: 'Hello!' }] }
+    }
+  }).chatCompletion({
+    placeholderValues: { name: 'Alice' },
+    messagesHistory: [
+      { role: 'system', content: 'You are a helpful assistant.' }
+    ]
+  })
+);
+
 /**
  * Streaming with Config References.
  */


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

Previously, it is possible to provide orchestration config ref together with other orchestration config modules, which is wrong. I used Xor and adapted the config property check to make the properties mutual exclusive.\ 

```ts
new OrchestrationClient({
    id: 'test-config-id',
    promptTemplating: {
      model: { name: 'gpt-5-mini' },
      prompt: { template: [{ role: 'user', content: 'Hello!' }] }
    }
  }).chatCompletion({
    placeholderValues: { name: 'Alice' },
    messagesHistory: [
      { role: 'system', content: 'You are a helpful assistant.' }
    ]
  })
```

For reviewer, please double check the behaviour and feel free to take the PR over.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
