### PR TITLE
chore: Reorder workflow step configuration

### DIFF
--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -39,34 +39,36 @@ runs:
 
     - name: "Check Whether PR Is Mergeable"
       id: check
+      env:
+        GH_TOKEN: ${{ inputs.token }}
       run: |
         PR_JSON=$(gh pr view "${{ inputs.pr-ref }}" --repo "${{ inputs.repo }}" --json number,mergeable,reviewDecision,statusCheckRollup)
-        
+
         PR_NUMBER=$(jq -r '.number' <<< "$PR_JSON")
         PR_MERGEABLE=$(jq -r '.mergeable' <<< "$PR_JSON")
         PR_DECISION=$(jq -r '.reviewDecision' <<< "$PR_JSON")
-        
+
         echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
         echo "[DEBUG] PR #$PR_NUMBER (in ${{ inputs.repo }}) is mergeable: $PR_MERGEABLE with decision $PR_DECISION"
-        
+
         if [[ "$PR_DECISION" != "APPROVED" ]]; then
           echo "PR #$PR_NUMBER (in ${{ inputs.repo }}) has not been approved."
           echo "RESULT=false" >> $GITHUB_OUTPUT
           exit 0
         fi
-        
+
         if [[ "$PR_MERGEABLE" != "MERGEABLE" ]]; then
           echo "PR #$PR_NUMBER (in ${{ inputs.repo }}) is not mergeable (i.e. there are conflicts)."
           echo "RESULT=false" >> $GITHUB_OUTPUT
           exit 0
         fi
-        
+
         PR_CHECKS=$(jq -r '.statusCheckRollup' <<< "$PR_JSON")
-        
+
         # check runs are things like our CI pipeline
         FAILED_CHECK_RUNS=$(jq -r '.[] | select(.__typename == "CheckRun" and .conclusion != "SUCCESS" and .conclusion != "NEUTRAL")' <<< "$PR_CHECKS")
         EXCLUDED_WORKFLOWS=$(jq -r 'keys[]' <<< "${{ inputs.excluded-check-runs }}")
-        
+
         while IFS= read -r EXCLUDED_WORKFLOW; do
           if [[ -z "$EXCLUDED_WORKFLOW" ]]; then
             continue
@@ -74,9 +76,9 @@ runs:
           if [[ -z "$FAILED_CHECK_RUNS" ]]; then
             break
           fi
-        
+
           EXCLUDED_STEPS=$(jq -r --arg workflow "$EXCLUDED_WORKFLOW" '.[$workflow] | .[]' <<< "${{ inputs.excluded-check-runs }}")
-        
+
           if [[ -z "$EXCLUDED_STEPS" ]]; then
             # the provided list is empty, so ignore all steps of the workflow
             FAILED_CHECK_RUNS=$(jq -r --arg workflow "$EXCLUDED_WORKFLOW" 'select(.workflowName != $workflow)' <<< "$FAILED_CHECK_RUNS")
@@ -89,14 +91,14 @@ runs:
             done <<< "$EXCLUDED_STEPS"
           fi
         done <<< "$EXCLUDED_WORKFLOWS"
-        
+
         if [[ -n "$FAILED_CHECK_RUNS" ]]; then
           echo "PR #$PR_NUMBER (in ${{ inputs.repo }}) contains failed check runs: "
           echo "$FAILED_CHECK_RUNS"
           echo "RESULT=false" >> $GITHUB_OUTPUT
           exit 0
         fi
-        
+
         # context checks are things like the license agreement check
         FAILED_CONTEXT_CHECKS=$(jq -r '.[] | select(.__typename == "StatusContext" and .state != "SUCCESS" and .state != "NEUTRAL")' <<< "$PR_CHECKS")
         if [[ -n "$FAILED_CONTEXT_CHECKS" ]]; then
@@ -105,11 +107,9 @@ runs:
           echo "RESULT=false" >> $GITHUB_OUTPUT
           exit 0
         fi
-        
+
         echo "RESULT=true" >> $GITHUB_OUTPUT
       shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.token }}
 
     - name: "Fail If PR Is Not Mergeable"
       if: ${{ inputs.fail-on-unmergeable == 'true' && steps.check.outputs.RESULT != 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,8 @@ jobs:
         run: pnpm check:deps
       - name: License Check
         uses: sap/cloud-sdk-js/.github/actions/check-license@license-checker
-      - run: pnpm doc
-        name: API Doc Check
+      - name: API Doc Check
+        run: pnpm doc
 
   dependabot:
     runs-on: ubuntu-latest
@@ -73,13 +73,13 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Approve a PR
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr review --approve "$PR_URL"
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -30,17 +30,17 @@ jobs:
           registry-token: ${{ secrets.NPM_TOKEN_ARTIFACTORY }}
           persist-credentials: 'true'
       - name: Bump version
-        uses: sap/cloud-sdk-js/.github/actions/changesets-fixed-version-bump@main
         id: bump
+        uses: sap/cloud-sdk-js/.github/actions/changesets-fixed-version-bump@main
         with:
           majorVersion: ${{ inputs.majorVersion }}
       - name: Merge and write changelogs
         id: merge-changelogs
-        uses: sap/cloud-sdk-js/.github/actions/merge-and-write-changelogs@main
         env:
           VERSION: ${{ steps.bump.outputs.version }}
-      - uses: sap/cloud-sdk-js/.github/actions/commit-and-tag@main
-        name: Commit and tag
+        uses: sap/cloud-sdk-js/.github/actions/merge-and-write-changelogs@main
+      - name: Commit and tag
+        uses: sap/cloud-sdk-js/.github/actions/commit-and-tag@main
         with:
           version: ${{ steps.bump.outputs.version }}
           user-name: ${{ vars.SAP_AI_SDK_BOT_NAME }}
@@ -97,11 +97,11 @@ jobs:
 
       - name: Open Release notes and API docs PR
         id: open_pr
-        working-directory: ./ai-sdk-docs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BOT_EMAIL: ${{ vars.SAP_AI_SDK_BOT_EMAIL }}
           BOT_NAME: ${{ vars.SAP_AI_SDK_BOT_NAME }}
+        working-directory: ./ai-sdk-docs
         run: |
           git config --local user.email "$BOT_EMAIL"
           git config --local user.name "$BOT_NAME"

--- a/.github/workflows/delete-dist-tag.yml
+++ b/.github/workflows/delete-dist-tag.yml
@@ -19,6 +19,8 @@ jobs:
           cache: 'pnpm'
 
       - name: delete dist tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
         run: |
           npm dist-tag rm @sap-ai-sdk/ai-api ${{ inputs.tag }}
           npm dist-tag rm @sap-ai-sdk/foundation-models ${{ inputs.tag }}
@@ -27,5 +29,3 @@ jobs:
           npm dist-tag rm @sap-ai-sdk/document-grounding ${{ inputs.tag }}
           npm dist-tag rm @sap-ai-sdk/langchain ${{ inputs.tag }}
           npm dist-tag rm @sap-ai-sdk/prompt-registry ${{ inputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -13,17 +13,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Determine Changed Files
         id: changed-files
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           ALL_FILES=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files.[] | select(.additions > 0) | .path')
           CHANGED_FILES="${ALL_FILES//$'\n'/,}"
 
           echo "[DEBUG] Following files have been changed: $CHANGED_FILES"
           echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Vale
         # vale fails if the PR is too large, e.g. when updating API docs
         if: ${{ github.event.pull_request.changed_files < 100 }}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         uses: vale-cli/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         with:
           # version of 'vale' to use
@@ -35,6 +37,3 @@ jobs:
           separator: ','
           # let review dog fail if there are errors
           fail_on_error: true
-        env:
-          # Required
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -12,11 +12,11 @@ jobs:
         with:
           registry-token: ${{ secrets.NPM_TOKEN_ARTIFACTORY }}
       - name: Get Changelog
-        uses: sap/cloud-sdk-js/.github/actions/get-changelog@main
         id: get-changelog
-      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        env:
+        uses: sap/cloud-sdk-js/.github/actions/get-changelog@main
+      - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           draft: true
           body: ${{ steps.get-changelog.outputs.changelog }}

--- a/.github/workflows/fosstars.yml
+++ b/.github/workflows/fosstars.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           registry-token: ${{ secrets.NPM_TOKEN_ARTIFACTORY }}
       - name: 'Run OWASP Dependency Check'
-        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main
         id: depcheck
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main
         with:
           project: ${{ github.repository }}
           path: '.'

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -14,8 +14,8 @@ jobs:
   lint-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        env:
+      - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:
           subjectPattern: ^[A-Z].+$ # no lowercase letters at the beginning

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -14,13 +14,13 @@ jobs:
           node-version: '24'
           registry-token: ${{ secrets.NPM_TOKEN_ARTIFACTORY }}
       - name: Update smoke test dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ARTIFACTORY }}
         run: |
           # Always use latest SDK packages for smoke tests to ensure they are tested against the latest version. The registry is set to npmjs to avoid issues with outdated packages in the Artifactory registry.
           pnpm config set --location=project @sap-ai-sdk:registry https://registry.npmjs.org/
           pnpm config set --location=project @sap-cloud-sdk:registry https://registry.npmjs.org/
           pnpm --filter @sap-ai-sdk/smoke-tests update '@sap-ai-sdk/*' --no-save --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ARTIFACTORY }}
       - name: Create deployment
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ARTIFACTORY }}

--- a/.github/workflows/spec-update-cron.yaml
+++ b/.github/workflows/spec-update-cron.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: 'Get orchestration version'
         id: orch-version
+        env:
+          TOKEN: ${{ secrets.GH_TOOLS_TOKEN }}
         run: |
           ORCH_VERSION=$(curl --fail --silent --request GET \
             --url "https://github.tools.sap/api/v3/repos/MLF-prod/mlf-gitops-prod/contents/services/llm-orchestration/source/Chart.yaml?ref=aws.eu-central-1.prod-eu/current" \
@@ -31,8 +33,6 @@ jobs:
           echo "Orchestration version: $ORCH_VERSION"
           ORCH_VERSION="$(echo "$ORCH_VERSION" | sed 's/-.*//')"
           echo "orchestration-branch=rel-$ORCH_VERSION" >> "$GITHUB_OUTPUT"
-        env:
-          TOKEN: ${{ secrets.GH_TOOLS_TOKEN }}
 
   # get-rpt-reference:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
I find this order much better readable: you always have the context before the actual execution.
Order: `name`, `id`, `if`, `env`, `working-directory`
