### PR TITLE
chore: Re-enable pnpm trust-policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,5 +24,5 @@ minimumReleaseAgeExclude:
   - '@hono/node-server@1.19.14'
   - 'langsmith@0.5.20'
 
-# TODO: This is failing too often, wait for pnpm-updates
-# trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 131400 # 3 months
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

> Allows ignoring the trust policy check for packages published more than the specified number of minutes ago. This is useful when enabling strict trust policies, as it allows older versions of packages (which may lack a process for publishing with signatures or provenance) to be installed without manual exclusion, assuming they are safe due to their age.

Alternatively we could also use `trustPolicyExclude` but 3 months should give sufficient headroom and would not require maintaining a list of dependencies.

https://pnpm.io/settings#trustpolicyignoreafter

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
