### PR TITLE
chore: Add suppression for OWASP dependency scan check

### DIFF
--- a/.github/owasp-suppressions.xml
+++ b/.github/owasp-suppressions.xml
@@ -8,4 +8,12 @@
       <packageUrl regex="true">^pkg:npm/express@.*$</packageUrl>
       <vulnerabilityName>CVE-2024-10491</vulnerabilityName>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+         file name: hono:=4.12.10
+         CVE-2026-39408: hono has been upgraded to 4.12.14 which fixes this vulnerability. False positive due to NVD/OSS Index matching on the old version string.
+      ]]></notes>
+      <packageUrl regex="true">^pkg:npm/hono@.*$</packageUrl>
+      <vulnerabilityName>CVE-2026-39408</vulnerabilityName>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
## Context

For some reason, the security scan fails with:
```
One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
hono:=4.12.10 (pkg:npm/hono@4.12.10, cpe:2.3:a:hono:hono:4.12.10:*:*:*:*:*:*:*): CVE-2026-39408(5.9)
```
even though the hono was updated to later versions. Hence, adding a suppression.
