### PR TITLE
feat(orchestration): Allow array for encoding_format in EmbeddingModelParams

### DIFF
--- a/packages/orchestration/src/orchestration-types.ts
+++ b/packages/orchestration/src/orchestration-types.ts
@@ -816,7 +816,7 @@ export type EmbeddingModelParams = Omit<
   OriginalEmbeddingsModelParams,
   'encoding_format'
 > & {
-  encoding_format?: EncodingFormat;
+  encoding_format?: EncodingFormat | EncodingFormat[];
 };
 
 /**

--- a/tests/type-tests/test/orchestration-embedding.test-d.ts
+++ b/tests/type-tests/test/orchestration-embedding.test-d.ts
@@ -12,7 +12,6 @@ import type {
   EmbeddingsUsage,
   ModuleResultsBase
 } from '@sap-ai-sdk/orchestration/internal.js';
-
 /**
  * Basic Embedding Client Construction.
  */
@@ -285,3 +284,56 @@ expectError<EmbeddingData>({
   embedding: [0.1, 0.2],
   index: 0
 });
+
+/**
+ * encoding_format accepts a single value or an array (Cohere multi-format support).
+ */
+expectAssignable<EmbeddingModelDetails>({
+  name: 'cohere--single-serving-embed',
+  params: {
+    encoding_format: 'float'
+  }
+});
+
+expectAssignable<EmbeddingModelDetails>({
+  name: 'cohere--single-serving-embed',
+  params: {
+    encoding_format: ['float', 'int8']
+  }
+});
+
+expectAssignable<EmbeddingModelDetails>({
+  name: 'cohere--single-serving-embed',
+  params: {
+    encoding_format: ['float', 'int8', 'uint8', 'binary', 'ubinary', 'base64']
+  }
+});
+
+/**
+ * Error: encoding_format with invalid value should fail.
+ */
+expectError(
+  new OrchestrationEmbeddingClient({
+    embeddings: {
+      model: {
+        name: 'text-embedding-3-small',
+        params: {
+          encoding_format: 'invalid-format'
+        }
+      }
+    }
+  })
+);
+
+expectError(
+  new OrchestrationEmbeddingClient({
+    embeddings: {
+      model: {
+        name: 'text-embedding-3-small',
+        params: {
+          encoding_format: ['float', 'invalid-format']
+        }
+      }
+    }
+  })
+);


### PR DESCRIPTION
## What changed

- `EmbeddingModelParams.encoding_format`: `EncodingFormat` → `EncodingFormat | EncodingFormat[]`
- Added type tests for single value, array, and invalid format rejection

## Why

The generated spec (`embeddings-model-params.ts`) already allows `EncodingFormat | EncodingFormat[]`, but the SDK public type was more restrictive.

Cohere Embed v4 accepts an array of `embedding_types` and returns `EmbeddingMultiFormat` — this change unblocks that use case.