### PR TITLE
chore(orchestration): Export types from schema that are used in public API - Method 1

### DIFF
--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -89,5 +89,16 @@ export type {
   ChatCompletionTool,
   FunctionObject,
   Error as OrchestrationError,
-  Citation
+  Citation,
+  TextContent,
+  CacheControl,
+  TokenUsage,
+  MessageToolCalls,
+  LlmChoice,
+  ModuleResults,
+  ModuleResultsBase,
+  ModuleResultsStreaming,
+  LlmChoiceStreaming,
+  ToolCallChunk,
+  EmbeddingsUsage
 } from './client/api/schema/index.js';


### PR DESCRIPTION
## Context

This ensure the types show up/expand in tsdoc.
https://github.com/SAP/ai-sdk-js-backlog/issues/507

Found the missing types via CC + TS lsp.

Closes #1878

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
