### PR TITLE
chore: Replace `--import tsx/esm` with `tsx`

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Update release notes file
         id: update-notes
         run: |
-          pnpm node --import tsx/esm -e "import { addCurrentChangelog } from './scripts/add-changelog.ts'; addCurrentChangelog()"
+          pnpm tsx --eval "import { addCurrentChangelog } from './scripts/add-changelog.ts'; addCurrentChangelog()"
 
       - name: Open release notes PR
         id: open-pr

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "pnpm -r run lint:fix",
     "generate": "pnpm -r run generate",
     "apply-patches": "pnpm -r run --if-present apply-patches",
-    "doc": "node --import tsx/esm scripts/generate-docs.ts",
+    "doc": "tsx scripts/generate-docs.ts",
     "ai-api": "pnpm -F=@sap-ai-sdk/ai-api run",
     "core": "pnpm -F=@sap-ai-sdk/core run",
     "document-grounding": "pnpm -F=@sap-ai-sdk/document-grounding run",

--- a/packages/ai-api/package.json
+++ b/packages/ai-api/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint . && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -c",
     "lint:fix": "eslint . --fix && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --log-level error",
     "generate": "openapi-generator --generateESM --clearOutputDir -i ./src/spec/AI_CORE_API.yaml -o ./src/client && pnpm update-imports && pnpm lint:fix",
-    "update-imports": "node --import tsx/esm ../../scripts/update-imports.ts ./src/client/AI_CORE_API"
+    "update-imports": "tsx ../../scripts/update-imports.ts ./src/client/AI_CORE_API"
   },
   "dependencies": {
     "@sap-ai-sdk/core": "workspace:^",

--- a/packages/document-grounding/package.json
+++ b/packages/document-grounding/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint . && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -c",
     "lint:fix": "eslint . --fix && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --log-level error",
     "generate": "openapi-generator --generateESM --clearOutputDir -i ./src/spec/api.yaml -o ./src/client -s ./src/spec/options-per-service.json && pnpm update-imports && pnpm lint:fix",
-    "update-imports": "node --import tsx/esm ../../scripts/update-imports.ts ./src/client/api",
+    "update-imports": "tsx ../../scripts/update-imports.ts ./src/client/api",
     "apply-patches": "git apply ./patches/backward-compat-getDataRepositoryById-order.patch"
   },
   "dependencies": {

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "eslint \"**/*.ts\" --fix && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --log-level error",
     "generate": "openapi-generator --generateESM --clearOutputDir -i ./src/spec/api.yaml -o ./src/client",
     "postgenerate": "rm ./src/client/api/*.ts && pnpm rename-generated-files && pnpm lint:fix",
-    "rename-generated-files": "node --import tsx/esm ../../scripts/postgenerate-orchestration.ts ./src/client/api"
+    "rename-generated-files": "tsx ../../scripts/postgenerate-orchestration.ts ./src/client/api"
   },
   "dependencies": {
     "@sap-ai-sdk/ai-api": "workspace:^",

--- a/packages/prompt-registry/package.json
+++ b/packages/prompt-registry/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "eslint . --fix && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --log-level error",
     "generate": "openapi-generator --generateESM --clearOutputDir -i ./src/spec/prompt-registry.yaml -o ./src/client",
     "postgenerate": "pnpm update-imports && pnpm orval && pnpm lint:fix",
-    "update-imports": "node --import tsx/esm ../../scripts/update-imports.ts ./src/client/prompt-registry"
+    "update-imports": "tsx ../../scripts/update-imports.ts ./src/client/prompt-registry"
   },
   "dependencies": {
     "@sap-ai-sdk/core": "workspace:^",

--- a/packages/rpt/package.json
+++ b/packages/rpt/package.json
@@ -32,9 +32,9 @@
     "lint:fix": "eslint . --fix && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --log-level error",
     "generate": "openapi-generator --generateESM --clearOutputDir -i ./src/spec/rpt.json -o ./src/client",
     "postgenerate": "pnpm update-imports && pnpm make-rpt-internal && pnpm lint:fix",
-    "update-imports": "node --import tsx/esm ../../scripts/update-imports.ts ./src/client/rpt",
-    "make-rpt-internal": "node --import tsx/esm ../../scripts/postgenerate-rpt.ts ./src/client/rpt/rpt-api.ts",
-    "pregenerate": "node --import tsx/esm ../../scripts/pregenerate-rpt.ts ./src/spec/rpt.json"
+    "update-imports": "tsx ../../scripts/update-imports.ts ./src/client/rpt",
+    "make-rpt-internal": "tsx ../../scripts/postgenerate-rpt.ts ./src/client/rpt/rpt-api.ts",
+    "pregenerate": "tsx ../../scripts/pregenerate-rpt.ts ./src/spec/rpt.json"
   },
   "dependencies": {
     "@sap-ai-sdk/ai-api": "workspace:^",

--- a/sample-code/package.json
+++ b/sample-code/package.json
@@ -12,9 +12,9 @@
     "dist/**/*.d.ts.map"
   ],
   "scripts": {
-    "start": "node --import tsx/esm src/server.ts",
-    "local": "node --env-file=.env --import tsx/esm src/server.ts",
-    "agent-tutorial": "node --env-file=.env --import tsx/esm src/tutorials/travel-itinerary-agent.ts",
+    "start": "tsx src/server.ts",
+    "local": "tsx --env-file=.env src/server.ts",
+    "agent-tutorial": "tsx --env-file=.env src/tutorials/travel-itinerary-agent.ts",
     "compile": "tsc",
     "dev": "tsc -w",
     "lint": "eslint . && prettier . --config ../.prettierrc --ignore-path ../.prettierignore -c",

--- a/tests/e2e-tests/package.json
+++ b/tests/e2e-tests/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "cleanup-deployments": "node --import tsx/esm ./src/utils/cleanup-deployments.ts",
+    "cleanup-deployments": "tsx ./src/utils/cleanup-deployments.ts",
     "lint": "eslint . && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -c",
     "lint:fix": "eslint . --fix && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --log-level error"
   },


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

`--import tsx/esm` lead to issues/regressions on node 24 that `tsx`-cli does not have.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
