### PR TITLE
fix: Strip dangling sourceMappingURL directive from internal.js shims

### DIFF
--- a/packages/ai-api/internal.js
+++ b/packages/ai-api/internal.js
@@ -1,2 +1,1 @@
 export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/core/internal.js
+++ b/packages/core/internal.js
@@ -1,2 +1,1 @@
 export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/document-grounding/internal.js
+++ b/packages/document-grounding/internal.js
@@ -1,2 +1,1 @@
 export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/foundation-models/internal.js
+++ b/packages/foundation-models/internal.js
@@ -1,2 +1,1 @@
 export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/langchain/internal.js
+++ b/packages/langchain/internal.js
@@ -1,2 +1,1 @@
 export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/orchestration/internal.js
+++ b/packages/orchestration/internal.js
@@ -1,2 +1,1 @@
 export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/prompt-registry/internal.js
+++ b/packages/prompt-registry/internal.js
@@ -1,2 +1,1 @@
 export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/rpt/internal.js
+++ b/packages/rpt/internal.js
@@ -1,2 +1,1 @@
 export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#573.

## What this PR does and why it is needed

Each package's root-level `internal.js` shim is a hand-written re-export:

```js
export * from './dist/internal.js';
//# sourceMappingURL=internal.js.map
```

The `sourceMappingURL=internal.js.map` directive is dangling — no `internal.js.map` is produced next to the shim (it's a checked-in static file, not a `tsc` output) and none is shipped in the published tarball. Consumer toolchains that honor `sourceMappingURL` emit warnings such as:

```
ERROR  failed to read input source map: failed to find input source map file
"internal.js.map" in "node_modules/@sap-ai-sdk/ai-api/internal.js"
```

This was reproduced with `@swc/jest` (`sourceMaps: "inline"`) in a downstream project that whitelists `@sap-ai-sdk/*` through `transformIgnorePatterns` so its files are transformed by swc. The warning is non-fatal but pollutes CI logs.

This PR removes the dangling line from all eight shims. Source maps for the actual `dist/` outputs are unaffected — they're still emitted by `tsc` and shipped via the existing `dist/**/*.js.map` glob in each `package.json`.

Affected files (byte-identical before this change):

- `packages/ai-api/internal.js`
- `packages/core/internal.js`
- `packages/document-grounding/internal.js`
- `packages/foundation-models/internal.js`
- `packages/langchain/internal.js`
- `packages/orchestration/internal.js`
- `packages/prompt-registry/internal.js`
- `packages/rpt/internal.js`