### PR TITLE
chore: Replace internal.js shim with explicit export

### DIFF
--- a/packages/ai-api/internal.d.ts
+++ b/packages/ai-api/internal.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.d.ts.map

--- a/packages/ai-api/internal.js
+++ b/packages/ai-api/internal.js
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/ai-api/package.json
+++ b/packages/ai-api/package.json
@@ -15,13 +15,21 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./internal.js": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    }
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map",
-    "internal.js",
-    "internal.d.ts"
+    "dist/**/*.d.ts.map"
   ],
   "scripts": {
     "compile": "tsc",

--- a/packages/core/internal.d.ts
+++ b/packages/core/internal.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.d.ts.map

--- a/packages/core/internal.js
+++ b/packages/core/internal.js
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,13 +15,21 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./internal.js": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    }
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map",
-    "internal.js",
-    "internal.d.ts"
+    "dist/**/*.d.ts.map"
   ],
   "scripts": {
     "compile": "tsc",

--- a/packages/document-grounding/internal.d.ts
+++ b/packages/document-grounding/internal.d.ts
@@ -1,3 +1,0 @@
-// eslint-disable-next-line import-x/no-internal-modules
-export * from './dist/internal.js';
-// # sourceMappingURL=internal.d.ts.map

--- a/packages/document-grounding/internal.js
+++ b/packages/document-grounding/internal.js
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/document-grounding/package.json
+++ b/packages/document-grounding/package.json
@@ -18,13 +18,21 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./internal.js": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    }
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map",
-    "internal.js",
-    "internal.d.ts"
+    "dist/**/*.d.ts.map"
   ],
   "scripts": {
     "compile": "tsc",

--- a/packages/foundation-models/internal.d.ts
+++ b/packages/foundation-models/internal.d.ts
@@ -1,3 +1,0 @@
-// eslint-disable-next-line import-x/no-internal-modules
-export * from './dist/internal.js';
-// # sourceMappingURL=internal.d.ts.map

--- a/packages/foundation-models/internal.js
+++ b/packages/foundation-models/internal.js
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/foundation-models/package.json
+++ b/packages/foundation-models/package.json
@@ -16,13 +16,21 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./internal.js": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    }
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map",
-    "internal.js",
-    "internal.d.ts"
+    "dist/**/*.d.ts.map"
   ],
   "scripts": {
     "compile": "tsc",

--- a/packages/langchain/internal.d.ts
+++ b/packages/langchain/internal.d.ts
@@ -1,3 +1,0 @@
-// eslint-disable-next-line import-x/no-internal-modules
-export * from './dist/internal.js';
-// # sourceMappingURL=internal.d.ts.map

--- a/packages/langchain/internal.js
+++ b/packages/langchain/internal.js
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -15,13 +15,21 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./internal.js": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    }
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map",
-    "internal.js",
-    "internal.d.ts"
+    "dist/**/*.d.ts.map"
   ],
   "scripts": {
     "compile": "tsc",

--- a/packages/orchestration/internal.d.ts
+++ b/packages/orchestration/internal.d.ts
@@ -1,3 +1,0 @@
-// eslint-disable-next-line import-x/no-internal-modules
-export * from './dist/internal.js';
-// # sourceMappingURL=internal.d.ts.map

--- a/packages/orchestration/internal.js
+++ b/packages/orchestration/internal.js
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -16,13 +16,21 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./internal.js": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    }
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map",
-    "internal.js",
-    "internal.d.ts"
+    "dist/**/*.d.ts.map"
   ],
   "scripts": {
     "compile": "tsc",

--- a/packages/prompt-registry/internal.d.ts
+++ b/packages/prompt-registry/internal.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.d.ts.map

--- a/packages/prompt-registry/internal.js
+++ b/packages/prompt-registry/internal.js
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/prompt-registry/package.json
+++ b/packages/prompt-registry/package.json
@@ -16,13 +16,21 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./internal.js": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    }
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map",
-    "internal.js",
-    "internal.d.ts"
+    "dist/**/*.d.ts.map"
   ],
   "scripts": {
     "compile": "tsc",

--- a/packages/rpt/internal.d.ts
+++ b/packages/rpt/internal.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.d.ts.map

--- a/packages/rpt/internal.js
+++ b/packages/rpt/internal.js
@@ -1,2 +1,0 @@
-export * from './dist/internal.js';
-//# sourceMappingURL=internal.js.map

--- a/packages/rpt/package.json
+++ b/packages/rpt/package.json
@@ -16,13 +16,21 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./internal.js": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    }
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map",
-    "internal.js",
-    "internal.d.ts"
+    "dist/**/*.d.ts.map"
   ],
   "scripts": {
     "compile": "tsc",


### PR DESCRIPTION
## Context

> [!WARNING]
> Not targeting main to enable canary releases.

Closes SAP/ai-sdk-js#1896.
Closes https://github.com/SAP/ai-sdk-js-backlog/issues/573.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
