### PR TITLE
chore: use npm token

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ registries:
   sap-artifactory:
     type: npm-registry
     url: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/
-    token: ${{secrets.DBOT_NPM_TOKEN_ARTIFACTORY}}
+    token: ${{secrets.NPM_TOKEN_ARTIFACTORY}}
     replaces-base: true
 updates:
   - package-ecosystem: npm


### PR DESCRIPTION
use the npm token instead of the duplicate dbot token
