### PR TITLE
chore: Handle zizmor warning on check-pr workflow

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -7,13 +7,21 @@ on:
       - edited
       - synchronize
 
+permissions: {}
+
 jobs:
   check-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          sparse-checkout: |
+            .github/PULL_REQUEST_TEMPLATE.md
+            .changeset
       - name: Collect changed files
         id: changed-files
         uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad # v47.0.5


### PR DESCRIPTION
## Context

The check-PR was created when the zizmor configuration was less strict, handle excessive permissions warning by adding explicit permissions.
Also add `sparse-checkout` for performance.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
