### PR TITLE
chore: Update `parseBatchOutput()` to handle `Buffer`

### DIFF
--- a/packages/foundation-models/src/azure-openai/azure-openai-batch-output.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-batch-output.ts
@@ -51,9 +51,13 @@ export async function parseBatchOutput(
     text = data;
   } else if (Buffer.isBuffer(data)) {
     text = data.toString('utf-8');
-  } else {
-    // Blob case
+  } else if (data instanceof Blob) {
     text = await data.text();
+  } else {
+    // typeguard - all cases handled
+  	data satisfies never;
+  	// let if fail in a natural way
+  	text = data as any;
   }
   return text
     .split('\n')

--- a/packages/foundation-models/src/azure-openai/azure-openai-batch-output.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-batch-output.ts
@@ -38,13 +38,23 @@ export interface BatchOutputLine {
 }
 
 /**
- * Parses a batch output Blob (JSONL format) into typed output lines.
- * @param blob - The Blob returned from FileApi.fileDownload().
+ * Parses a batch output JSONL payload into typed output lines.
+ * @param data - The data returned from FileApi.fileDownload(), as a Blob, Buffer, or string.
  * @returns A Promise resolving to an array of parsed output lines.
  * @experimental This API is experimental and may change at any time without prior notice.
  */
-export async function parseBatchOutput(blob: Blob): Promise<BatchOutputLine[]> {
-  const text = await blob.text();
+export async function parseBatchOutput(
+  data: Blob | Buffer | string
+): Promise<BatchOutputLine[]> {
+  let text: string;
+  if (typeof data === 'string') {
+    text = data;
+  } else if (Buffer.isBuffer(data)) {
+    text = data.toString('utf-8');
+  } else {
+    // Blob case
+    text = await data.text();
+  }
   return text
     .split('\n')
     .filter(line => line.trim().length)

--- a/packages/foundation-models/src/azure-openai/azure-openai-batch-output.ts
+++ b/packages/foundation-models/src/azure-openai/azure-openai-batch-output.ts
@@ -55,9 +55,9 @@ export async function parseBatchOutput(
     text = await data.text();
   } else {
     // typeguard - all cases handled
-  	data satisfies never;
-  	// let if fail in a natural way
-  	text = data as any;
+    data satisfies never;
+    // let if fail in a natural way
+    text = data as any;
   }
   return text
     .split('\n')


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

Actually the generated client currently returns a `Buffer`

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
