### PR TITLE
fix: Improve error handling for non-JSON responses in SseStream

### DIFF
--- a/.changeset/twenty-lemons-yawn.md
+++ b/.changeset/twenty-lemons-yawn.md
@@ -1,0 +1,5 @@
+---
+"@sap-ai-sdk/core": patch
+---
+
+[fix] Improve error message when server sends a non-JSON response during streaming.

--- a/packages/core/src/stream/sse-stream.test.ts
+++ b/packages/core/src/stream/sse-stream.test.ts
@@ -1,8 +1,18 @@
 import assert from 'assert';
 import {
+  SseStream,
   _iterSseMessages,
   _decodeChunks as decodeChunks
 } from './sse-stream.js';
+
+class TestSseStream<Item> extends SseStream<Item> {
+  static create<Item>(response: any): TestSseStream<Item> {
+    return SseStream.transformToSseStream<Item>(
+      response,
+      new AbortController()
+    ) as TestSseStream<Item>;
+  }
+}
 
 describe('line decoder', () => {
   test('basic', () => {
@@ -317,6 +327,28 @@ describe('streaming decoding', () => {
 
     expect(stream.next()).rejects.toThrow(
       'Invalid SSE payload: {"error":"Something went wrong"}'
+    );
+  });
+});
+
+describe('SseStream JSON parsing error handling', () => {
+  test('includes raw payload in error when SSE data is not valid JSON', async () => {
+    async function* body(): AsyncGenerator<Buffer> {
+      yield Buffer.from('data: {"content": "hello"}\n');
+      yield Buffer.from('\n');
+      yield Buffer.from('data: Error in L\n');
+      yield Buffer.from('\n');
+    }
+
+    const stream = TestSseStream.create<any>({ data: body() });
+
+    const iter = stream[Symbol.asyncIterator]();
+    await iter.next();
+
+    const error = await iter.next().catch(e => e);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.cause?.message).toContain(
+      'Server sent an unexpected non-JSON response: Error in L'
     );
   });
 });

--- a/packages/core/src/stream/sse-stream.ts
+++ b/packages/core/src/stream/sse-stream.ts
@@ -40,7 +40,7 @@ export class SseStream<Item> implements AsyncIterable<Item> {
             data = JSON.parse(sse.data);
           } catch (e: any) {
             throw new ErrorWithCause(
-              `Server sent an unexpected non-JSON response: ${sse.data.slice(0, 256)}...`,
+              `Server sent an unexpected non-JSON response: ${sse.data.length > 256 ? `${sse.data.slice(0, 256)}...` : sse.data}`,
               e
             );
           }

--- a/packages/core/src/stream/sse-stream.ts
+++ b/packages/core/src/stream/sse-stream.ts
@@ -40,7 +40,7 @@ export class SseStream<Item> implements AsyncIterable<Item> {
             data = JSON.parse(sse.data);
           } catch (e: any) {
             throw new ErrorWithCause(
-              `Server sent an unexpected non-JSON response: ${sse.data.length > 256 ? `${sse.data.slice(0, 256)}...` : sse.data}`,
+              `Server sent an unexpected non-JSON response: ${sse.data.length > 256 ? sse.data.slice(0, 256) + '...' : sse.data}`,
               e
             );
           }

--- a/packages/core/src/stream/sse-stream.ts
+++ b/packages/core/src/stream/sse-stream.ts
@@ -39,7 +39,10 @@ export class SseStream<Item> implements AsyncIterable<Item> {
           try {
             data = JSON.parse(sse.data);
           } catch (e: any) {
-            throw new ErrorWithCause('Could not parse message into JSON', e);
+            throw new ErrorWithCause(
+              `Server sent an unexpected non-JSON response: ${sse.data.slice(0, 256)}...`,
+              e
+            );
           }
 
           if (data?.error) {


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#486.

Rewords the message a bit and includes a (window of) the string payload to better surface any server error messages.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
