### PR TITLE
chore: Sync model types from SAP Notes

### DIFF
--- a/.changeset/model-types-sync-2026-06-25.md
+++ b/.changeset/model-types-sync-2026-06-25.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/core': minor
+---
+
+[Improvement] Added `gpt-5.1` to the available model list.

--- a/packages/core/src/model-types.ts
+++ b/packages/core/src/model-types.ts
@@ -14,6 +14,7 @@ export type AzureOpenAiChatModel = LiteralUnion<
   | 'gpt-5.4'
   | 'gpt-5.4-nano'
   | 'gpt-5.5'
+  | 'gpt-5.1'
   | 'o3'
   | 'o4-mini'
 >;

--- a/scripts/sap-models.json
+++ b/scripts/sap-models.json
@@ -351,6 +351,16 @@
   },
   {
     "executableId": "azure-openai (Azure)",
+    "model": "gpt-5.1",
+    "version": "2025-11-13 (latest)",
+    "availableInOrchestration": "",
+    "deprecated": "",
+    "retirementDate": "",
+    "suggestedReplacement": "",
+    "retired": ""
+  },
+  {
+    "executableId": "azure-openai (Azure)",
     "model": "gpt-5-mini",
     "version": "2025-08-07",
     "availableInOrchestration": "yes",
@@ -476,6 +486,16 @@
     "availableInOrchestration": "yes",
     "deprecated": "",
     "retirementDate": "2026-10-16",
+    "suggestedReplacement": "",
+    "retired": ""
+  },
+  {
+    "executableId": "gcp-vertexai (Google)",
+    "model": "gemini-3.5-flash",
+    "version": "001 (latest)",
+    "availableInOrchestration": "",
+    "deprecated": "",
+    "retirementDate": "",
     "suggestedReplacement": "",
     "retired": ""
   },


### PR DESCRIPTION
Automated sync of model types from [SAP Notes 3437766](https://me.sap.com/notes/3437766).

Closes https://github.com/SAP/ai-sdk-js-backlog/issues/601

## Changes

- Added `gpt-5.1` to `AzureOpenAiChatModel` in `model-types.ts`
- Added `gpt-5.1` and `gemini-3.5-flash` to `sap-models.json`

## Definition of Done
- [x] Model names are correct
- [x] Compilation passes
- [x] Release notes / Changeset updated if needed