### PR TITLE
chore: push logic down to deployment resolver

### DIFF
--- a/packages/ai-api/src/utils/deployment-resolver.test.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.test.ts
@@ -55,12 +55,12 @@ describe('deployment resolver', () => {
     });
 
     it('should retrieve deployment from cache if available', async () => {
-      const opts = {
+      const options = {
         scenarioId: 'foundation-models',
         model: { name: 'gpt-5-mini', version: '0613' }
       };
-      deploymentCache.set(opts, { id: '1' } as AiDeployment);
-      const id = await resolveDeploymentId(opts);
+      deploymentCache.set(options, { id: '1' } as AiDeployment);
+      const id = await resolveDeploymentId(options);
       expect(id).toEqual('1');
       expect(nock.isDone()).toEqual(false);
     });
@@ -213,7 +213,7 @@ describe('resolveDeploymentUrlById', () => {
 });
 
 describe('resolveDeploymentUrlForModel', () => {
-  const baseOpts = {
+  const baseoptions = {
     scenarioId: 'foundation-models',
     executableId: 'azure-openai'
   };
@@ -237,12 +237,12 @@ describe('resolveDeploymentUrlForModel', () => {
       }
     );
 
-    const url = await resolveDeploymentUrlForModel('gpt-4.1', baseOpts);
+    const url = await resolveDeploymentUrlForModel('gpt-4.1', baseoptions);
 
     expect(url).toContain('inference/deployments/dep-001');
   });
 
-  it('uses resource group from modelDeployment when not in opts', async () => {
+  it('uses resource group from modelDeployment when not in options', async () => {
     mockDeploymentsList(
       {
         scenarioId: 'foundation-models',
@@ -258,7 +258,7 @@ describe('resolveDeploymentUrlForModel', () => {
 
     const url = await resolveDeploymentUrlForModel(
       { modelName: 'gpt-4.1', resourceGroup: 'custom-rg' },
-      baseOpts
+      baseoptions
     );
 
     expect(url).toContain('inference/deployments/dep-rg');
@@ -271,7 +271,7 @@ describe('resolveDeploymentUrlForModel', () => {
     );
 
     await expect(
-      resolveDeploymentUrlForModel('gpt-4.1', baseOpts)
+      resolveDeploymentUrlForModel('gpt-4.1', baseoptions)
     ).rejects.toThrow(
       "Deployment for model 'gpt-4.1' has no deployment URL. Ensure the deployment is running."
     );

--- a/packages/ai-api/src/utils/deployment-resolver.test.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.test.ts
@@ -7,7 +7,9 @@ import {
 import { type AiDeployment } from '../client/AI_CORE_API/index.js';
 import {
   getAllDeployments,
-  resolveDeploymentId
+  resolveDeploymentId,
+  resolveDeploymentUrlById,
+  resolveDeploymentUrlForModel
 } from './deployment-resolver.js';
 import { deploymentCache } from './deployment-cache.js';
 
@@ -164,3 +166,112 @@ function mockResponse() {
     { id: '2', model: { name: 'gpt-5-mini', version: '0613' } }
   );
 }
+
+describe('resolveDeploymentUrlById', () => {
+  beforeEach(() => {
+    mockClientCredentialsGrantCall();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('returns the deployment URL for a known ID', async () => {
+    nock(aiCoreDestination.url)
+      .get('/v2/lm/deployments/dep-123')
+      .reply(200, {
+        id: 'dep-123',
+        deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-123`
+      });
+
+    const url = await resolveDeploymentUrlById('dep-123', 'default');
+
+    expect(url).toContain('dep-123');
+  });
+
+  it('throws when the deployment request fails', async () => {
+    nock(aiCoreDestination.url)
+      .get('/v2/lm/deployments/missing-dep')
+      .reply(404, { message: 'Not Found' });
+
+    await expect(
+      resolveDeploymentUrlById('missing-dep', 'default')
+    ).rejects.toThrow("Fetching deployment for ID 'missing-dep' failed.");
+  });
+
+  it('throws when the deployment has no URL', async () => {
+    nock(aiCoreDestination.url)
+      .get('/v2/lm/deployments/no-url-dep')
+      .reply(200, { id: 'no-url-dep' });
+
+    await expect(
+      resolveDeploymentUrlById('no-url-dep', 'default')
+    ).rejects.toThrow(
+      "Deployment for ID 'no-url-dep' has no deployment URL. Ensure the deployment is running."
+    );
+  });
+});
+
+describe('resolveDeploymentUrlForModel', () => {
+  const baseOpts = { scenarioId: 'foundation-models', executableId: 'azure-openai' };
+
+  beforeEach(() => {
+    mockClientCredentialsGrantCall();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    deploymentCache.clear();
+  });
+
+  it('resolves URL via model name', async () => {
+    mockDeploymentsList(
+      { scenarioId: 'foundation-models', executableId: 'azure-openai' },
+      { id: 'dep-001', model: { name: 'gpt-4.1', version: 'latest' }, deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-001` }
+    );
+
+    const url = await resolveDeploymentUrlForModel('gpt-4.1', baseOpts);
+
+    expect(url).toContain('inference/deployments/dep-001');
+  });
+
+  it('resolves URL via deployment ID', async () => {
+    nock(aiCoreDestination.url)
+      .get('/v2/lm/deployments/dep-123')
+      .reply(200, {
+        id: 'dep-123',
+        deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-123`
+      });
+
+    const url = await resolveDeploymentUrlForModel({ deploymentId: 'dep-123' }, baseOpts);
+
+    expect(url).toContain('inference/deployments/dep-123');
+  });
+
+  it('uses resource group from modelDeployment when not in opts', async () => {
+    mockDeploymentsList(
+      { scenarioId: 'foundation-models', executableId: 'azure-openai', resourceGroup: 'custom-rg' },
+      { id: 'dep-rg', model: { name: 'gpt-4.1', version: 'latest' }, deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-rg` }
+    );
+
+    const url = await resolveDeploymentUrlForModel(
+      { modelName: 'gpt-4.1', resourceGroup: 'custom-rg' },
+      baseOpts
+    );
+
+    expect(url).toContain('inference/deployments/dep-rg');
+  });
+
+  it('throws when model deployment has no URL', async () => {
+    mockDeploymentsList(
+      { scenarioId: 'foundation-models', executableId: 'azure-openai' },
+      { id: 'dep-no-url', model: { name: 'gpt-4.1', version: 'latest' } }
+    );
+
+    await expect(
+      resolveDeploymentUrlForModel('gpt-4.1', baseOpts)
+    ).rejects.toThrow(
+      "Deployment for model 'gpt-4.1' has no deployment URL. Ensure the deployment is running."
+    );
+  });
+});

--- a/packages/ai-api/src/utils/deployment-resolver.test.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.test.ts
@@ -242,22 +242,6 @@ describe('resolveDeploymentUrlForModel', () => {
     expect(url).toContain('inference/deployments/dep-001');
   });
 
-  it('resolves URL via deployment ID', async () => {
-    nock(aiCoreDestination.url)
-      .get('/v2/lm/deployments/dep-123')
-      .reply(200, {
-        id: 'dep-123',
-        deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-123`
-      });
-
-    const url = await resolveDeploymentUrlForModel(
-      { deploymentId: 'dep-123' },
-      baseOpts
-    );
-
-    expect(url).toContain('inference/deployments/dep-123');
-  });
-
   it('uses resource group from modelDeployment when not in opts', async () => {
     mockDeploymentsList(
       {

--- a/packages/ai-api/src/utils/deployment-resolver.test.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.test.ts
@@ -213,7 +213,10 @@ describe('resolveDeploymentUrlById', () => {
 });
 
 describe('resolveDeploymentUrlForModel', () => {
-  const baseOpts = { scenarioId: 'foundation-models', executableId: 'azure-openai' };
+  const baseOpts = {
+    scenarioId: 'foundation-models',
+    executableId: 'azure-openai'
+  };
 
   beforeEach(() => {
     mockClientCredentialsGrantCall();
@@ -227,7 +230,11 @@ describe('resolveDeploymentUrlForModel', () => {
   it('resolves URL via model name', async () => {
     mockDeploymentsList(
       { scenarioId: 'foundation-models', executableId: 'azure-openai' },
-      { id: 'dep-001', model: { name: 'gpt-4.1', version: 'latest' }, deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-001` }
+      {
+        id: 'dep-001',
+        model: { name: 'gpt-4.1', version: 'latest' },
+        deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-001`
+      }
     );
 
     const url = await resolveDeploymentUrlForModel('gpt-4.1', baseOpts);
@@ -243,15 +250,26 @@ describe('resolveDeploymentUrlForModel', () => {
         deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-123`
       });
 
-    const url = await resolveDeploymentUrlForModel({ deploymentId: 'dep-123' }, baseOpts);
+    const url = await resolveDeploymentUrlForModel(
+      { deploymentId: 'dep-123' },
+      baseOpts
+    );
 
     expect(url).toContain('inference/deployments/dep-123');
   });
 
   it('uses resource group from modelDeployment when not in opts', async () => {
     mockDeploymentsList(
-      { scenarioId: 'foundation-models', executableId: 'azure-openai', resourceGroup: 'custom-rg' },
-      { id: 'dep-rg', model: { name: 'gpt-4.1', version: 'latest' }, deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-rg` }
+      {
+        scenarioId: 'foundation-models',
+        executableId: 'azure-openai',
+        resourceGroup: 'custom-rg'
+      },
+      {
+        id: 'dep-rg',
+        model: { name: 'gpt-4.1', version: 'latest' },
+        deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-rg`
+      }
     );
 
     const url = await resolveDeploymentUrlForModel(

--- a/packages/ai-api/src/utils/deployment-resolver.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.ts
@@ -243,25 +243,25 @@ export async function getAllDeployments(
  * If given a deployment ID, fetches the URL for that specific deployment.
  * If given a model name, looks up a running deployment for that model.
  * @param modelDeployment - Deployment identified by model name/version or by ID.
- * @param opts - Base resolution options (scenarioId, executableId, etc.) without `model` — that is derived from `modelDeployment`.
+ * @param options - Base resolution options (scenarioId, executableId, etc.) without `model` — that is derived from `modelDeployment`.
  * @returns A promise of the deployment URL.
  * @internal
  */
 export async function resolveDeploymentUrlForModel(
   modelDeployment: ModelDeployment,
-  opts: Omit<DeploymentResolutionOptions, 'model'>
+  options: Omit<DeploymentResolutionOptions, 'model'>
 ): Promise<string> {
   const resourceGroup =
-    opts.resourceGroup ?? getResourceGroup(modelDeployment) ?? 'default';
+    options.resourceGroup ?? getResourceGroup(modelDeployment) ?? 'default';
   if (isDeploymentIdConfig(modelDeployment)) {
     return resolveDeploymentUrlById(
       modelDeployment.deploymentId,
       resourceGroup,
-      opts.destination
+      options.destination
     );
   }
   const model = translateToFoundationModel(modelDeployment);
-  const url = await resolveDeploymentUrl({ ...opts, resourceGroup, model });
+  const url = await resolveDeploymentUrl({ ...options, resourceGroup, model });
   if (!url) {
     throw new Error(
       `Deployment for model '${model.name}' has no deployment URL. Ensure the deployment is running.`

--- a/packages/ai-api/src/utils/deployment-resolver.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.ts
@@ -172,6 +172,40 @@ export async function resolveDeploymentUrl(
 }
 
 /**
+ * Fetch a deployment by ID and return its URL.
+ * Throws if the request fails or the deployment has no URL.
+ * @param deploymentId - The ID of the deployment.
+ * @param resourceGroup - The resource group of the deployment.
+ * @param destination - The destination to use for the request.
+ * @returns A promise of the deployment URL.
+ * @internal
+ */
+export async function resolveDeploymentUrlById(
+  deploymentId: string,
+  resourceGroup: string,
+  destination?: HttpDestinationOrFetchOptions
+): Promise<string> {
+  const { deploymentUrl } = await DeploymentApi.deploymentGet(
+    deploymentId,
+    {},
+    { 'AI-Resource-Group': resourceGroup }
+  )
+    .execute(destination)
+    .catch((err: any) => {
+      throw new ErrorWithCause(
+        `Fetching deployment for ID '${deploymentId}' failed.`,
+        err
+      );
+    });
+  if (!deploymentUrl) {
+    throw new Error(
+      `Deployment for ID '${deploymentId}' has no deployment URL. Ensure the deployment is running.`
+    );
+  }
+  return deploymentUrl;
+}
+
+/**
  * Get all deployments that match the given criteria.
  * @param opts - The options for the deployment resolution.
  * @returns A promise of an array of deployments.
@@ -202,6 +236,37 @@ export async function getAllDeployments(
   } catch (error: any) {
     throw new ErrorWithCause('Failed to fetch the list of deployments.', error);
   }
+}
+
+/**
+ * Resolve the deployment URL for a model deployment.
+ * If given a deployment ID, fetches the URL for that specific deployment.
+ * If given a model name, looks up a running deployment for that model.
+ * @param modelDeployment - Deployment identified by model name/version or by ID.
+ * @param opts - Base resolution options (scenarioId, executableId, etc.) without `model` — that is derived from `modelDeployment`.
+ * @returns A promise of the deployment URL.
+ * @internal
+ */
+export async function resolveDeploymentUrlForModel(
+  modelDeployment: ModelDeployment,
+  opts: Omit<DeploymentResolutionOptions, 'model'>
+): Promise<string> {
+  const resourceGroup = opts.resourceGroup ?? getResourceGroup(modelDeployment) ?? 'default';
+  if (isDeploymentIdConfig(modelDeployment)) {
+    return resolveDeploymentUrlById(
+      modelDeployment.deploymentId,
+      resourceGroup,
+      opts.destination
+    );
+  }
+  const model = translateToFoundationModel(modelDeployment);
+  const url = await resolveDeploymentUrl({ ...opts, resourceGroup, model });
+  if (!url) {
+    throw new Error(
+      `Deployment for model '${model.name}' has no deployment URL. Ensure the deployment is running.`
+    );
+  }
+  return url;
 }
 
 /**

--- a/packages/ai-api/src/utils/deployment-resolver.ts
+++ b/packages/ai-api/src/utils/deployment-resolver.ts
@@ -251,7 +251,8 @@ export async function resolveDeploymentUrlForModel(
   modelDeployment: ModelDeployment,
   opts: Omit<DeploymentResolutionOptions, 'model'>
 ): Promise<string> {
-  const resourceGroup = opts.resourceGroup ?? getResourceGroup(modelDeployment) ?? 'default';
+  const resourceGroup =
+    opts.resourceGroup ?? getResourceGroup(modelDeployment) ?? 'default';
   if (isDeploymentIdConfig(modelDeployment)) {
     return resolveDeploymentUrlById(
       modelDeployment.deploymentId,

--- a/packages/openai/src/config.test.ts
+++ b/packages/openai/src/config.test.ts
@@ -23,17 +23,6 @@ describe('createOpenAiConfig', () => {
   });
 
   describe('baseURL resolution', () => {
-    it('resolves URL via model name', async () => {
-      mockDeploymentsList(
-        { scenarioId: 'foundation-models', executableId: 'azure-openai' },
-        defaultDeployment
-      );
-
-      const config = await createOpenAiConfig({ deployment: 'gpt-4.1' });
-
-      expect(config.baseURL).toContain('inference/deployments/dep-001');
-    });
-
     it('accepts a bare model name string', async () => {
       mockDeploymentsList(
         { scenarioId: 'foundation-models', executableId: 'azure-openai' },
@@ -43,43 +32,6 @@ describe('createOpenAiConfig', () => {
       const config = await createOpenAiConfig('gpt-4.1');
 
       expect(config.baseURL).toContain('inference/deployments/dep-001');
-    });
-
-    it('resolves URL via deployment ID', async () => {
-      nock(aiCoreDestination.url)
-        .get('/v2/lm/deployments/dep-123')
-        .reply(200, {
-          id: 'dep-123',
-          deploymentUrl: `${aiCoreDestination.url}/v2/inference/deployments/dep-123`
-        });
-
-      const config = await createOpenAiConfig({
-        deployment: { deploymentId: 'dep-123' }
-      });
-
-      expect(config.baseURL).toContain('dep-123');
-    });
-
-    it('throws when deploymentGet returns a 404', async () => {
-      nock(aiCoreDestination.url)
-        .get('/v2/lm/deployments/missing-dep')
-        .reply(404, { message: 'Not Found' });
-
-      await expect(
-        createOpenAiConfig({ deployment: { deploymentId: 'missing-dep' } })
-      ).rejects.toThrow("Fetching deployment for ID 'missing-dep' failed.");
-    });
-
-    it('throws when deployment ID resolves to no URL', async () => {
-      nock(aiCoreDestination.url)
-        .get('/v2/lm/deployments/no-url-dep')
-        .reply(200, { id: 'no-url-dep' });
-
-      await expect(
-        createOpenAiConfig({ deployment: { deploymentId: 'no-url-dep' } })
-      ).rejects.toThrow(
-        "Deployment for ID 'no-url-dep' has no deployment URL. Ensure the deployment is running."
-      );
     });
   });
 

--- a/packages/openai/src/config.ts
+++ b/packages/openai/src/config.ts
@@ -4,10 +4,7 @@ import {
 } from '@sap-ai-sdk/ai-api/internal.js';
 import { createTokenProvider } from './token-provider.js';
 import type { AzureClientOptions } from 'openai/azure';
-import type {
-  SapOpenAiInput,
-  SapOpenAiOptions
-} from './types.js';
+import type { SapOpenAiInput, SapOpenAiOptions } from './types.js';
 
 const defaultApiVersion = '2024-10-21';
 

--- a/packages/openai/src/config.ts
+++ b/packages/openai/src/config.ts
@@ -1,14 +1,13 @@
 import {
-  resolveDeploymentUrl,
-  getResourceGroup,
-  translateToFoundationModel,
-  isDeploymentIdConfig
+  resolveDeploymentUrlForModel,
+  getResourceGroup
 } from '@sap-ai-sdk/ai-api/internal.js';
-import { DeploymentApi } from '@sap-ai-sdk/ai-api';
-import { ErrorWithCause } from '@sap-cloud-sdk/util';
 import { createTokenProvider } from './token-provider.js';
 import type { AzureClientOptions } from 'openai/azure';
-import type { SapOpenAiInput, SapOpenAiOptions } from './types.js';
+import type {
+  SapOpenAiInput,
+  SapOpenAiOptions
+} from './types.js';
 
 const defaultApiVersion = '2024-10-21';
 
@@ -43,38 +42,12 @@ export async function createOpenAiConfig(
   } = opts;
 
   const resourceGroup = getResourceGroup(deployment) ?? 'default';
-
-  const baseUrl = isDeploymentIdConfig(deployment)
-    ? (
-        await DeploymentApi.deploymentGet(
-          deployment.deploymentId,
-          {},
-          { 'AI-Resource-Group': resourceGroup }
-        )
-          .execute(destination)
-          .catch((err: any) => {
-            throw new ErrorWithCause(
-              `Fetching deployment for ID '${deployment.deploymentId}' failed.`,
-              err
-            );
-          })
-      ).deploymentUrl
-    : await resolveDeploymentUrl({
-        scenarioId: 'foundation-models',
-        executableId: 'azure-openai',
-        model: translateToFoundationModel(deployment),
-        resourceGroup,
-        destination
-      });
-
-  if (!baseUrl) {
-    const identifier = isDeploymentIdConfig(deployment)
-      ? `ID '${deployment.deploymentId}'`
-      : `model '${translateToFoundationModel(deployment).name}'`;
-    throw new Error(
-      `Deployment for ${identifier} has no deployment URL. Ensure the deployment is running.`
-    );
-  }
+  const baseUrl = await resolveDeploymentUrlForModel(deployment, {
+    scenarioId: 'foundation-models',
+    executableId: 'azure-openai',
+    resourceGroup,
+    destination
+  });
 
   return {
     baseURL: baseUrl,


### PR DESCRIPTION
## Context

Related to SAP/ai-sdk-js-backlog#596.

## What this PR does and why it is needed

I noticed that this logic should be in the deployment resolver, especially as I would like to reuse it.