### PR TITLE
chore: Sync model types from SAP Notes and recent announcements 

### DIFF
--- a/.changeset/model-types-sync-2026-07-03.md
+++ b/.changeset/model-types-sync-2026-07-03.md
@@ -1,0 +1,5 @@
+---
+'@sap-ai-sdk/core': minor
+---
+
+[Improvement] Remove deprecated models `gpt-4.1` (retirement date: 2026-10-14), `gpt-4.1-mini` (retirement date: 2026-10-14), `o3` (retirement date: 2026-10-16) and `o4-mini` (retirement date: 2026-10-16).

--- a/packages/core/src/model-types.ts
+++ b/packages/core/src/model-types.ts
@@ -4,8 +4,6 @@ type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>);
  * Azure OpenAI models for chat completion.
  */
 export type AzureOpenAiChatModel = LiteralUnion<
-  | 'gpt-4.1'
-  | 'gpt-4.1-mini'
   | 'gpt-4.1-nano'
   | 'gpt-5'
   | 'gpt-5-mini'
@@ -15,8 +13,6 @@ export type AzureOpenAiChatModel = LiteralUnion<
   | 'gpt-5.4-nano'
   | 'gpt-5.5'
   | 'gpt-5.1'
-  | 'o3'
-  | 'o4-mini'
 >;
 
 /**

--- a/packages/openai/src/client.ts
+++ b/packages/openai/src/client.ts
@@ -29,7 +29,7 @@ export class SapOpenAi {
    * ```ts
    * import { SapOpenAi } from '@sap-ai-sdk/openai';
    *
-   * const client = await SapOpenAi.createClient('gpt-4.1');
+   * const client = await SapOpenAi.createClient('gpt-5.4');
    * await client.chat.completions.create({
    *   messages: [{ role: 'user', content: 'Hello!' }]
    * });

--- a/sample-code/src/llm-batch.ts
+++ b/sample-code/src/llm-batch.ts
@@ -41,7 +41,7 @@ export async function createBatch(
       type: 'llm-native',
       input: { uri: inputUri },
       output: { uri: outputUri },
-      spec: { provider: 'azure-openai', model: 'gpt-4.1' }
+      spec: { provider: 'azure-openai', model: 'gpt-5' }
     },
     defaultHeaders
   ).execute();
@@ -103,12 +103,12 @@ export async function uploadBatchInput(
 ): Promise<string> {
   const blob = createBatchInput([
     {
-      model: 'gpt-4.1',
+      model: 'gpt-5',
       messages: [{ role: 'user', content: 'What is machine learning?' }],
       max_tokens: 150
     },
     {
-      model: 'gpt-4.1',
+      model: 'gpt-5',
       messages: [
         { role: 'user', content: 'Explain neural networks in simple terms' }
       ],

--- a/scripts/sap-models.json
+++ b/scripts/sap-models.json
@@ -175,7 +175,7 @@
     "version": "1 (latest)",
     "availableInOrchestration": "yes",
     "deprecated": "Yes",
-    "retirementDate": "2026-09-10",
+    "retirementDate": "2026-09-14",
     "suggestedReplacement": "amazon--nova-lite 2",
     "retired": ""
   },
@@ -294,7 +294,7 @@
     "model": "gpt-4o",
     "version": "2024-11-20",
     "availableInOrchestration": "yes",
-    "deprecated": "",
+    "deprecated": "yes",
     "retirementDate": "2026-10-01",
     "suggestedReplacement": "gpt-5",
     "retired": ""
@@ -314,7 +314,7 @@
     "model": "gpt-4.1",
     "version": "2025-04-14",
     "availableInOrchestration": "yes",
-    "deprecated": "",
+    "deprecated": "yes",
     "retirementDate": "2026-10-14",
     "suggestedReplacement": "",
     "retired": ""
@@ -324,7 +324,7 @@
     "model": "gpt-4.1-mini",
     "version": "2025-04-14",
     "availableInOrchestration": "yes",
-    "deprecated": "",
+    "deprecated": "yes",
     "retirementDate": "2026-10-14",
     "suggestedReplacement": "",
     "retired": ""
@@ -444,7 +444,7 @@
     "model": "o1",
     "version": "2024-12-17",
     "availableInOrchestration": "yes",
-    "deprecated": "",
+    "deprecated": "yes",
     "retirementDate": "2026-07-15",
     "suggestedReplacement": "",
     "retired": ""
@@ -454,7 +454,7 @@
     "model": "o3-mini",
     "version": "2025-01-31",
     "availableInOrchestration": "yes",
-    "deprecated": "",
+    "deprecated": "yes",
     "retirementDate": "2026-08-02",
     "suggestedReplacement": "",
     "retired": ""
@@ -464,7 +464,7 @@
     "model": "o3",
     "version": "2025-04-16",
     "availableInOrchestration": "yes",
-    "deprecated": "",
+    "deprecated": "yes",
     "retirementDate": "2026-10-16",
     "suggestedReplacement": "",
     "retired": ""
@@ -474,7 +474,7 @@
     "model": "o4-mini",
     "version": "2025-04-16",
     "availableInOrchestration": "yes",
-    "deprecated": "",
+    "deprecated": "yes",
     "retirementDate": "2026-10-16",
     "suggestedReplacement": "",
     "retired": ""
@@ -514,8 +514,8 @@
     "model": "gemini-2.5-flash-image",
     "version": "001",
     "availableInOrchestration": "",
-    "deprecated": "",
-    "retirementDate": "",
+    "deprecated": "Yes",
+    "retirementDate": "2026-10-02",
     "suggestedReplacement": "",
     "retired": ""
   },
@@ -567,6 +567,16 @@
     "deprecated": "",
     "retirementDate": "",
     "suggestedReplacement": "mistralai--mistral-small-instruct",
+    "retired": "yes"
+  },
+  {
+    "executableId": "azure-openai (Azure)",
+    "model": "gpt-35-turbo",
+    "version": "0613",
+    "availableInOrchestration": "",
+    "deprecated": "",
+    "retirementDate": "",
+    "suggestedReplacement": "gpt-4o-mini",
     "retired": "yes"
   },
   {
@@ -717,6 +727,16 @@
     "deprecated": "",
     "retirementDate": "",
     "suggestedReplacement": "amazon--nova-premier",
+    "retired": "yes"
+  },
+  {
+    "executableId": "aws-bedrock (AWS)",
+    "model": "amazon--titan-image-generator",
+    "version": "2",
+    "availableInOrchestration": "",
+    "deprecated": "",
+    "retirementDate": "",
+    "suggestedReplacement": "",
     "retired": "yes"
   },
   {


### PR DESCRIPTION
Automated sync of model types from [SAP Notes 3437766](https://me.sap.com/notes/3437766).

## Changes

- Marked deprecated in `sap-models.json`: `gpt-4o` (2024-11-20), `gpt-4.1`, `gpt-4.1-mini`, `o1`, `o3-mini`, `o3`, `o4-mini`, `gemini-2.5-flash-image`
- Corrected `amazon--nova-premier` retirement date: 2026-09-10 → 2026-09-14
- Added retired entries: `gpt-35-turbo` v0613, `amazon--titan-image-generator` v2
- Removed from `model-types.ts`: `gpt-4.1`, `gpt-4.1-mini`, `o3`, `o4-mini`
- Updated sample code: `llm-batch.ts` → `gpt-5`, `packages/openai/src/client.ts` JSDoc → `gpt-5.4`

## Definition of Done
- [ ] Model names are correct
- [ ] Compilation passes
- [ ] Release notes / Changeset updated if needed