### PR TITLE
chore: Only run `generate` on target service package

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -156,7 +156,7 @@ jobs:
         id: generate
         if: steps.check-spec-changes.outputs.spec == 'true'
         run: |
-          pnpm generate
+          pnpm "$SERVICE" generate
 
       - name: 'Apply patches'
         id: apply-patches


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER

Otherwise even if service X is targeted Y might get re-generated without the Y patches being applied.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
