### PR TITLE
chore: Use different model in fallback E2E tests

### DIFF
--- a/sample-code/src/langchain-orchestration.ts
+++ b/sample-code/src/langchain-orchestration.ts
@@ -60,10 +60,10 @@ export async function invokeChain(): Promise<string> {
 export async function invokeChainWithFallbackConfigs(): Promise<string> {
   const orchestrationConfigs: LangChainOrchestrationModuleConfigList = [
     {
-      // First configuration with a non-existent model to trigger module fallback
+      // First configuration with a non-orchestration model to trigger module fallback
       promptTemplating: {
         model: {
-          name: 'non-existent-model'
+          name: 'sap-rpt-1-small'
         }
       }
     },
@@ -316,7 +316,7 @@ export async function streamChainWithFallbackConfigs(
     {
       promptTemplating: {
         model: {
-          name: 'non-existing-model'
+          name: 'sap-rpt-1-small'
         }
       }
     },

--- a/sample-code/src/orchestration.ts
+++ b/sample-code/src/orchestration.ts
@@ -977,10 +977,10 @@ export async function orchestrationSonarStreamWithCitations(
 export async function orchestrationWithFallbackConfigs(): Promise<OrchestrationResponse> {
   const orchestrationClient = new OrchestrationClient([
     {
-      // First configuration with a non-existent model to trigger module fallback
+      // First configuration with a non-orchestration model to trigger module fallback
       promptTemplating: {
         model: {
-          name: 'non-existent-model'
+          name: 'sap-rpt-1-small'
         }
       }
     },
@@ -1028,7 +1028,7 @@ export async function orchestrationStreamWithFallbackConfigs(): Promise<
     {
       promptTemplating: {
         model: {
-          name: 'non-existent-model'
+          name: 'sap-rpt-1-small'
         }
       }
     },


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#ISSUENUMBER.

This unbreaks some of the E2E tests, RPT is unlikely to be supported by orchestration.

That said, https://github.com/SAP/ai-sdk-js/actions/runs/28802437550 did pass.

Branch E2E: https://github.com/SAP/ai-sdk-js/actions/runs/28849027320

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
