### PR TITLE
feat(langchain): add cache_control support and richer token usage met…

### DIFF
--- a/.changeset/four-tigers-accept.md
+++ b/.changeset/four-tigers-accept.md
@@ -1,0 +1,7 @@
+---
+"@sap-ai-sdk/langchain": minor
+---
+
+[feat] Add `cache_control` call option to the LangChain orchestration client.
+When the `cache_control` option is set (directly or via the `orchestrationPromptCachingMiddleware()` middleware), a cache breakpoint is automatically applied to the request.
+  

--- a/.changeset/great-dots-cheat.md
+++ b/.changeset/great-dots-cheat.md
@@ -1,0 +1,6 @@
+---
+"@sap-ai-sdk/langchain": patch
+---
+
+[feat] Expose `cached_tokens` and `cache_creation_tokens` in `usage_metadata.input_token_details` for LangChain orchestration responses.
+  

--- a/packages/core/src/stream/line-decoder.ts
+++ b/packages/core/src/stream/line-decoder.ts
@@ -36,9 +36,7 @@ export class LineDecoder {
       return [];
     }
 
-    const trailingNewline = LineDecoder.NEWLINE_CHARS.has(
-      text[text.length - 1] || ''
-    );
+    const trailingNewline = LineDecoder.NEWLINE_CHARS.has(text.at(-1) || '');
     let lines = text.split(LineDecoder.NEWLINE_REGEXP);
 
     // if there is a trailing new line then the last entry will be an empty

--- a/packages/langchain/src/orchestration/client.test.ts
+++ b/packages/langchain/src/orchestration/client.test.ts
@@ -1385,4 +1385,159 @@ describe('orchestration service client', () => {
       });
     });
   });
+
+  describe('cache_control', () => {
+    // `messageIdx` is passed in (rather than computed as `length - 1`) so the
+    // assertion would fail if the implementation pinned the breakpoint to a
+    // different message than the last one.
+    function expectCacheControlAt(
+      messageIdx: number,
+      expectedContent: string,
+      expectedCacheControl: { type: string; ttl?: string }
+    ): (body: any) => boolean {
+      return (body: any): boolean => {
+        const template =
+          body?.config?.modules?.prompt_templating?.prompt?.template;
+        if (!Array.isArray(template) || messageIdx >= template.length) {
+          return false;
+        }
+        const target = template[messageIdx];
+        if (target?.role !== 'user' || !Array.isArray(target.content)) {
+          return false;
+        }
+        const [block] = target.content;
+        const targetHasExpectedBreakpoint =
+          target.content.length === 1 &&
+          block?.type === 'text' &&
+          block.text === expectedContent &&
+          block.cache_control?.type === expectedCacheControl.type &&
+          block.cache_control?.ttl === expectedCacheControl.ttl;
+
+        const otherMessagesHaveBreakpoint = template.some(
+          (msg: any, idx: number) =>
+            idx !== messageIdx && JSON.stringify(msg).includes('cache_control')
+        );
+
+        return targetHasExpectedBreakpoint && !otherMessagesHaveBreakpoint;
+      };
+    }
+
+    it('applies the cache_control breakpoint to the last user message in non-streaming requests', async () => {
+      mockInference(
+        {
+          data: expectCacheControlAt(0, 'Hello!', {
+            type: 'ephemeral',
+            ttl: '5m'
+          })
+        },
+        { data: mockResponse, status: 200 },
+        endpoint
+      );
+
+      const client = new OrchestrationClient(config, { maxRetries: 0 });
+      const response = await client.invoke(messages, {
+        cache_control: { type: 'ephemeral', ttl: '5m' }
+      });
+      expect(response.content).toBeDefined();
+    });
+
+    it('omits cache_control from the request body when the option is not set', async () => {
+      mockInference(
+        {
+          data: (body: any) => {
+            const template =
+              body?.config?.modules?.prompt_templating?.prompt?.template;
+            return (
+              Array.isArray(template) &&
+              !JSON.stringify(template).includes('cache_control')
+            );
+          }
+        },
+        { data: mockResponse, status: 200 },
+        endpoint
+      );
+
+      const client = new OrchestrationClient(config, { maxRetries: 0 });
+      await client.invoke(messages);
+    });
+
+    it('moves the cache_control breakpoint to the new last message across successive invocations', async () => {
+      // Turn 1: single user message — breakpoint at index 0.
+      mockInference(
+        {
+          data: expectCacheControlAt(0, 'Hello!', {
+            type: 'ephemeral',
+            ttl: '5m'
+          })
+        },
+        { data: mockResponse, status: 200 },
+        endpoint
+      );
+      // Turn 2: three messages — breakpoint advances to index 2.
+      mockInference(
+        {
+          data: expectCacheControlAt(2, 'Follow-up.', {
+            type: 'ephemeral',
+            ttl: '5m'
+          })
+        },
+        { data: mockResponse, status: 200 },
+        endpoint
+      );
+
+      const client = new OrchestrationClient(config, { maxRetries: 0 });
+      const callOptions = {
+        cache_control: { type: 'ephemeral' as const, ttl: '5m' as const }
+      };
+
+      await client.invoke(messages, callOptions);
+      await client.invoke(
+        [
+          { role: 'user' as const, content: 'Hello!' },
+          { role: 'assistant' as const, content: 'Hi there.' },
+          { role: 'user' as const, content: 'Follow-up.' }
+        ],
+        callOptions
+      );
+    });
+
+    it('honors a 1h ttl in the cache_control breakpoint', async () => {
+      mockInference(
+        {
+          data: expectCacheControlAt(0, 'Hello!', {
+            type: 'ephemeral',
+            ttl: '1h'
+          })
+        },
+        { data: mockResponse, status: 200 },
+        endpoint
+      );
+
+      const client = new OrchestrationClient(config, { maxRetries: 0 });
+      await client.invoke(messages, {
+        cache_control: { type: 'ephemeral', ttl: '1h' }
+      });
+    });
+
+    it('applies the cache_control breakpoint on the streaming path', async () => {
+      mockInference(
+        {
+          data: expectCacheControlAt(0, 'Hello!', {
+            type: 'ephemeral',
+            ttl: '5m'
+          })
+        },
+        { data: mockResponseStream, status: 200 },
+        endpoint
+      );
+
+      const client = new OrchestrationClient(config, { maxRetries: 0 });
+      const stream = await client.stream(messages, {
+        cache_control: { type: 'ephemeral', ttl: '5m' }
+      });
+      for await (const _chunk of stream) {
+        // drain
+      }
+    });
+  });
 });

--- a/packages/langchain/src/orchestration/client.ts
+++ b/packages/langchain/src/orchestration/client.ts
@@ -23,7 +23,8 @@ import {
   mapLangChainMessagesToOrchestrationMessages,
   mapOutputToChatResult,
   mapToolToChatCompletionTool,
-  mapOrchestrationChunkToLangChainMessageChunk
+  mapOrchestrationChunkToLangChainMessageChunk,
+  applyCacheControlToLastMessage
 } from './util.js';
 import type { NewTokenIndices } from '@langchain/core/callbacks/base';
 import type {
@@ -140,6 +141,9 @@ export class OrchestrationClient extends BaseChatModel<
 
     const { placeholderValues, customRequestConfig } = options;
     const allMessages = mapLangChainMessagesToOrchestrationMessages(messages);
+    if (options.cache_control) {
+      applyCacheControlToLastMessage(allMessages, options.cache_control);
+    }
     const mergedOrchestrationConfig = this.mergeOrchestrationConfigs(options);
 
     const res = await this.caller.callWithOptions(
@@ -350,6 +354,12 @@ export class OrchestrationClient extends BaseChatModel<
     options.signal?.throwIfAborted();
     const orchestrationMessages =
       mapLangChainMessagesToOrchestrationMessages(messages);
+    if (options.cache_control) {
+      applyCacheControlToLastMessage(
+        orchestrationMessages,
+        options.cache_control
+      );
+    }
 
     const { placeholderValues, customRequestConfig } = options;
     const mergedOrchestrationConfig = this.mergeOrchestrationConfigs(options);
@@ -404,11 +414,6 @@ export class OrchestrationClient extends BaseChatModel<
       const tokenUsage = chunk.getTokenUsage();
       if (tokenUsage) {
         generationInfo.token_usage = tokenUsage;
-        messageChunk.usage_metadata = {
-          input_tokens: tokenUsage.prompt_tokens,
-          output_tokens: tokenUsage.completion_tokens,
-          total_tokens: tokenUsage.total_tokens
-        };
       }
 
       const content = chunk.getDeltaContent() ?? '';

--- a/packages/langchain/src/orchestration/types.ts
+++ b/packages/langchain/src/orchestration/types.ts
@@ -5,6 +5,7 @@ import type {
   StreamOptions
 } from '@sap-ai-sdk/orchestration';
 import type {
+  CacheControl,
   ChatCompletionTool,
   ResponseFormatJsonObject,
   ResponseFormatJsonSchema,
@@ -59,6 +60,20 @@ export type OrchestrationCallOptions = Pick<
   streamOptions?: StreamOptions;
   responseFormat?:
     ResponseFormatText | ResponseFormatJsonObject | ResponseFormatJsonSchema;
+  /**
+   * Cache control configuration for prompt caching. When provided, a cache
+   * breakpoint is automatically applied to the last cacheable text block of
+   * the last message so the breakpoint advances naturally as the conversation
+   * grows. This removes the need to place `cache_control` on individual
+   * content blocks manually.
+   *
+   * Only applies to models that support `cache_control` through orchestration
+   * (Anthropic Claude and Amazon Nova model families). Other models will
+   * ignore the directive. See the
+   * {@link https://help.sap.com/docs/sap-ai-core/generative-ai/prompt-caching | SAP AI Core prompt caching docs}
+   * for supported models and breakpoint limits.
+   */
+  cache_control?: CacheControl;
 };
 
 /**

--- a/packages/langchain/src/orchestration/util.test.ts
+++ b/packages/langchain/src/orchestration/util.test.ts
@@ -16,16 +16,20 @@ import {
   mapLangChainMessagesToOrchestrationMessages,
   mapOutputToChatResult,
   mapOrchestrationChunkToLangChainMessageChunk,
-  mapToolToOrchestrationFunction
+  mapToolToOrchestrationFunction,
+  applyCacheControlToLastMessage
 } from './util.js';
 import type { OrchestrationMessage } from './orchestration-message.js';
 import type { ToolCallChunk } from '@langchain/core/messages/tool';
 import type {
+  CacheControl,
+  ChatMessage,
   CompletionPostResponse,
   MessageToolCall,
   ToolCallChunk as OrchestrationToolCallChunk,
   CompletionPostResponseStreaming,
-  FunctionObject
+  FunctionObject,
+  TokenUsage
 } from '@sap-ai-sdk/orchestration/internal.js';
 
 describe('mapLangChainMessagesToOrchestrationMessages', () => {
@@ -276,6 +280,189 @@ describe('mapOutputToChatResult', () => {
       }
     ]);
   });
+
+  it('should preserve prompt token details in response metadata', () => {
+    const completionResponse: CompletionPostResponse = {
+      final_result: {
+        id: 'test-id',
+        object: 'chat.completion',
+        created: 1634840000,
+        model: 'test-model',
+        choices: [
+          {
+            message: {
+              content: 'Test content',
+              role: 'assistant'
+            },
+            finish_reason: 'stop',
+            index: 0
+          }
+        ],
+        usage: {
+          completion_tokens: 10,
+          prompt_tokens: 20,
+          total_tokens: 30,
+          prompt_tokens_details: {
+            cached_tokens: 15,
+            cache_creation_tokens: 5
+          }
+        }
+      },
+      request_id: 'req-123',
+      intermediate_results: {}
+    };
+
+    const result = mapOutputToChatResult(completionResponse);
+    const message = result.generations[0].message as AIMessage;
+
+    expect(message.response_metadata).toEqual({
+      tokenUsage: {
+        completionTokens: 10,
+        promptTokens: 20,
+        totalTokens: 30
+      }
+    });
+
+    expect(message.usage_metadata).toEqual({
+      input_tokens: 20,
+      output_tokens: 10,
+      total_tokens: 30,
+      input_token_details: {
+        cache_read: 15,
+        cache_creation: 5
+      }
+    });
+  });
+
+  it('should map reasoning tokens to output_token_details', () => {
+    const completionResponse: CompletionPostResponse = {
+      final_result: {
+        id: 'test-id',
+        object: 'chat.completion',
+        created: 1634840000,
+        model: 'test-model',
+        choices: [
+          {
+            message: {
+              content: 'Test content',
+              role: 'assistant'
+            },
+            finish_reason: 'stop',
+            index: 0
+          }
+        ],
+        usage: {
+          completion_tokens: 42,
+          prompt_tokens: 20,
+          total_tokens: 62,
+          completion_tokens_details: {
+            reasoning_tokens: 7
+          }
+        }
+      },
+      request_id: 'req-123',
+      intermediate_results: {}
+    };
+
+    const result = mapOutputToChatResult(completionResponse);
+    const message = result.generations[0].message as AIMessage;
+
+    expect(message.usage_metadata).toEqual({
+      input_tokens: 20,
+      output_tokens: 42,
+      total_tokens: 62,
+      output_token_details: {
+        reasoning: 7
+      }
+    });
+  });
+
+  it('should map cache and reasoning token details together', () => {
+    const completionResponse: CompletionPostResponse = {
+      final_result: {
+        id: 'test-id',
+        object: 'chat.completion',
+        created: 1634840000,
+        model: 'test-model',
+        choices: [
+          {
+            message: {
+              content: 'Test content',
+              role: 'assistant'
+            },
+            finish_reason: 'stop',
+            index: 0
+          }
+        ],
+        usage: {
+          completion_tokens: 42,
+          prompt_tokens: 20,
+          total_tokens: 62,
+          prompt_tokens_details: {
+            cached_tokens: 12,
+            cache_creation_tokens: 3
+          },
+          completion_tokens_details: {
+            reasoning_tokens: 4
+          }
+        }
+      },
+      request_id: 'req-123',
+      intermediate_results: {}
+    };
+
+    const result = mapOutputToChatResult(completionResponse);
+    const message = result.generations[0].message as AIMessage;
+
+    expect(message.usage_metadata).toEqual({
+      input_tokens: 20,
+      output_tokens: 42,
+      total_tokens: 62,
+      input_token_details: {
+        cache_read: 12,
+        cache_creation: 3
+      },
+      output_token_details: {
+        reasoning: 4
+      }
+    });
+  });
+
+  it('should default missing reasoning_tokens to 0 when completion_tokens_details is present', () => {
+    const completionResponse: CompletionPostResponse = {
+      final_result: {
+        id: 'test-id',
+        object: 'chat.completion',
+        created: 1634840000,
+        model: 'test-model',
+        choices: [
+          {
+            message: { content: 'Test content', role: 'assistant' },
+            finish_reason: 'stop',
+            index: 0
+          }
+        ],
+        usage: {
+          completion_tokens: 5,
+          prompt_tokens: 5,
+          total_tokens: 10,
+          // Sibling field present, reasoning_tokens omitted.
+          completion_tokens_details: {
+            accepted_prediction_tokens: 2
+          }
+        }
+      },
+      request_id: 'req-123',
+      intermediate_results: {}
+    };
+
+    const result = mapOutputToChatResult(completionResponse);
+    const message = result.generations[0].message as AIMessage;
+
+    expect(message.usage_metadata?.output_token_details).toEqual({
+      reasoning: 0
+    });
+  });
 });
 
 describe('mapToolToOrchestrationFunction', () => {
@@ -337,11 +524,7 @@ describe('mapOrchestrationChunkToLangChainMessageChunk', () => {
     content?: string,
     toolCallChunks?: OrchestrationToolCallChunk[],
     finishReason?: string,
-    tokenUsage?: {
-      completion_tokens: number;
-      prompt_tokens: number;
-      total_tokens: number;
-    }
+    tokenUsage?: TokenUsage
   ): OrchestrationStreamChunkResponse {
     const mockData: CompletionPostResponseStreaming = {
       request_id: 'req-123',
@@ -432,5 +615,242 @@ describe('mapOrchestrationChunkToLangChainMessageChunk', () => {
     };
     expect(result.tool_call_chunks?.[0]).toEqual(expectedToolCallChunk);
     expect(result).toMatchSnapshot('AIMessageChunk with tool call chunks');
+  });
+
+  it('omits usage_metadata when the chunk carries no token usage', () => {
+    const result = mapOrchestrationChunkToLangChainMessageChunk(
+      createMockChunk('partial')
+    );
+
+    expect(result.usage_metadata).toBeUndefined();
+  });
+
+  it('maps token usage on the chunk to usage_metadata', () => {
+    const result = mapOrchestrationChunkToLangChainMessageChunk(
+      createMockChunk(undefined, undefined, 'stop', {
+        completion_tokens: 271,
+        prompt_tokens: 17,
+        total_tokens: 288
+      })
+    );
+
+    expect(result.usage_metadata).toEqual({
+      input_tokens: 17,
+      output_tokens: 271,
+      total_tokens: 288
+    });
+  });
+
+  it('maps prompt cache token details to input_token_details on the chunk', () => {
+    const result = mapOrchestrationChunkToLangChainMessageChunk(
+      createMockChunk(undefined, undefined, 'stop', {
+        completion_tokens: 10,
+        prompt_tokens: 20,
+        total_tokens: 30,
+        prompt_tokens_details: {
+          cached_tokens: 15,
+          cache_creation_tokens: 5
+        }
+      })
+    );
+
+    expect(result.usage_metadata).toEqual({
+      input_tokens: 20,
+      output_tokens: 10,
+      total_tokens: 30,
+      input_token_details: {
+        cache_read: 15,
+        cache_creation: 5
+      }
+    });
+  });
+
+  it('maps reasoning tokens to output_token_details on the chunk', () => {
+    const result = mapOrchestrationChunkToLangChainMessageChunk(
+      createMockChunk(undefined, undefined, 'stop', {
+        completion_tokens: 42,
+        prompt_tokens: 20,
+        total_tokens: 62,
+        completion_tokens_details: {
+          reasoning_tokens: 7
+        }
+      })
+    );
+
+    expect(result.usage_metadata).toEqual({
+      input_tokens: 20,
+      output_tokens: 42,
+      total_tokens: 62,
+      output_token_details: {
+        reasoning: 7
+      }
+    });
+  });
+});
+
+describe('applyCacheControlToLastMessage', () => {
+  const cacheControl: CacheControl = { type: 'ephemeral', ttl: '5m' };
+
+  it('wraps a string user message into a text block carrying cache_control', () => {
+    const messages: ChatMessage[] = [{ role: 'user', content: 'Hello' }];
+
+    applyCacheControlToLastMessage(messages, cacheControl);
+
+    expect(messages[0]).toEqual({
+      role: 'user',
+      content: [{ type: 'text', text: 'Hello', cache_control: cacheControl }]
+    });
+  });
+
+  it('wraps a string system message into a text block carrying cache_control', () => {
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'You are helpful.' }
+    ];
+
+    applyCacheControlToLastMessage(messages, cacheControl);
+
+    expect(messages[0]).toEqual({
+      role: 'system',
+      content: [
+        {
+          type: 'text',
+          text: 'You are helpful.',
+          cache_control: cacheControl
+        }
+      ]
+    });
+  });
+
+  it('wraps a string tool message into a text block carrying cache_control', () => {
+    const messages: ChatMessage[] = [
+      { role: 'tool', content: 'Tool result.', tool_call_id: 'call-1' }
+    ];
+
+    applyCacheControlToLastMessage(messages, cacheControl);
+
+    expect(messages[0]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call-1',
+      content: [
+        {
+          type: 'text',
+          text: 'Tool result.',
+          cache_control: cacheControl
+        }
+      ]
+    });
+  });
+
+  it('attaches cache_control to the last text block of an array content', () => {
+    const messages: ChatMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'First part.' },
+          { type: 'text', text: 'Second part.' }
+        ]
+      }
+    ];
+
+    applyCacheControlToLastMessage(messages, cacheControl);
+
+    expect(messages[0].content).toEqual([
+      { type: 'text', text: 'First part.' },
+      { type: 'text', text: 'Second part.', cache_control: cacheControl }
+    ]);
+  });
+
+  it('moves the breakpoint to the last cacheable block when an earlier one already has cache_control', () => {
+    const existingCacheControl: CacheControl = {
+      type: 'ephemeral',
+      ttl: '1h'
+    };
+    const messages: ChatMessage[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'First part.',
+            cache_control: existingCacheControl
+          },
+          { type: 'text', text: 'Second part.' }
+        ]
+      }
+    ];
+
+    applyCacheControlToLastMessage(messages, cacheControl);
+
+    expect(messages[0].content).toEqual([
+      {
+        type: 'text',
+        text: 'First part.',
+        cache_control: existingCacheControl
+      },
+      { type: 'text', text: 'Second part.', cache_control: cacheControl }
+    ]);
+  });
+
+  it('attaches cache_control only to the last message when multiple are present', () => {
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'Hi.' },
+      { role: 'assistant', content: 'Hello!' },
+      { role: 'user', content: 'How are you?' }
+    ];
+
+    applyCacheControlToLastMessage(messages, cacheControl);
+
+    expect(messages[0]).toEqual({
+      role: 'system',
+      content: 'You are helpful.'
+    });
+    expect(messages[1]).toEqual({ role: 'user', content: 'Hi.' });
+    expect(messages[2]).toEqual({ role: 'assistant', content: 'Hello!' });
+    expect(messages[3]).toEqual({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'How are you?', cache_control: cacheControl }
+      ]
+    });
+  });
+
+  it('falls back to image_url/file blocks for user messages without trailing text', () => {
+    const messages: ChatMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'See the image:' },
+          { type: 'image_url', image_url: { url: 'https://example.com/x.png' } }
+        ]
+      }
+    ];
+
+    applyCacheControlToLastMessage(messages, cacheControl);
+
+    expect(messages[0].content).toEqual([
+      { type: 'text', text: 'See the image:' },
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/x.png' },
+        cache_control: cacheControl
+      }
+    ]);
+  });
+
+  it('does not mutate assistant messages with string content', () => {
+    const messages: ChatMessage[] = [{ role: 'assistant', content: 'Hello!' }];
+
+    applyCacheControlToLastMessage(messages, cacheControl);
+
+    expect(messages[0]).toEqual({ role: 'assistant', content: 'Hello!' });
+  });
+
+  it('does not throw on an empty message list', () => {
+    const messages: ChatMessage[] = [];
+    expect(() =>
+      applyCacheControlToLastMessage(messages, cacheControl)
+    ).not.toThrow();
+    expect(messages).toEqual([]);
   });
 });

--- a/packages/langchain/src/orchestration/util.test.ts
+++ b/packages/langchain/src/orchestration/util.test.ts
@@ -119,6 +119,28 @@ describe('mapBaseMessageToChatMessage', () => {
     });
   });
 
+  it('should clone system message content blocks so cache_control does not leak back', () => {
+    const systemMessage = new SystemMessage({
+      content: [{ type: 'text', text: 'System text' }]
+    });
+    const messages = mapLangChainMessagesToOrchestrationMessages([
+      systemMessage
+    ]);
+
+    applyCacheControlToLastMessage(messages, { type: 'ephemeral', ttl: '5m' });
+
+    expect(messages[0].content).toEqual([
+      {
+        type: 'text',
+        text: 'System text',
+        cache_control: { type: 'ephemeral', ttl: '5m' }
+      }
+    ]);
+    expect(systemMessage.content).toEqual([
+      { type: 'text', text: 'System text' }
+    ]);
+  });
+
   it('should map AIMessage to ChatMessage with assistant role', () => {
     const aiMessage = new AIMessage('AI message content');
 
@@ -428,7 +450,7 @@ describe('mapOutputToChatResult', () => {
     });
   });
 
-  it('should default missing reasoning_tokens to 0 when completion_tokens_details is present', () => {
+  it('should omit output_token_details when reasoning_tokens is absent', () => {
     const completionResponse: CompletionPostResponse = {
       final_result: {
         id: 'test-id',
@@ -459,9 +481,7 @@ describe('mapOutputToChatResult', () => {
     const result = mapOutputToChatResult(completionResponse);
     const message = result.generations[0].message as AIMessage;
 
-    expect(message.usage_metadata?.output_token_details).toEqual({
-      reasoning: 0
-    });
+    expect(message.usage_metadata?.output_token_details).toBeUndefined();
   });
 });
 
@@ -735,6 +755,25 @@ describe('applyCacheControlToLastMessage', () => {
         {
           type: 'text',
           text: 'Tool result.',
+          cache_control: cacheControl
+        }
+      ]
+    });
+  });
+
+  it('wraps a string developer message into a text block carrying cache_control', () => {
+    const messages: ChatMessage[] = [
+      { role: 'developer', content: 'Prefer concise answers.' }
+    ];
+
+    applyCacheControlToLastMessage(messages, cacheControl);
+
+    expect(messages[0]).toEqual({
+      role: 'developer',
+      content: [
+        {
+          type: 'text',
+          text: 'Prefer concise answers.',
           cache_control: cacheControl
         }
       ]

--- a/packages/langchain/src/orchestration/util.ts
+++ b/packages/langchain/src/orchestration/util.ts
@@ -360,7 +360,7 @@ function buildUsageMetadata(usage: TokenUsage): {
     input_tokens: usage.prompt_tokens,
     output_tokens: usage.completion_tokens,
     total_tokens: usage.total_tokens,
-    ...(usage.prompt_tokens_details && {
+    ...(usage.prompt_tokens_details?.cached_tokens !== undefined && {
       input_token_details: {
         cache_read: usage.prompt_tokens_details.cached_tokens ?? 0,
         cache_creation: usage.prompt_tokens_details.cache_creation_tokens ?? 0

--- a/packages/langchain/src/orchestration/util.ts
+++ b/packages/langchain/src/orchestration/util.ts
@@ -12,6 +12,7 @@ import type {
 } from '@sap-ai-sdk/orchestration';
 import type {
   AssistantChatMessage,
+  CacheControl,
   ChatCompletionTool,
   ChatMessage,
   ChatMessageContent,
@@ -19,6 +20,7 @@ import type {
   FunctionObject,
   MessageToolCalls,
   SystemChatMessage,
+  TokenUsage,
   ToolChatMessage,
   UserChatMessage,
   TemplateRef,
@@ -229,6 +231,63 @@ export function mapLangChainMessagesToOrchestrationMessages(
 }
 
 /**
+ * Applies a cache breakpoint to the last cacheable block of the last message in place.
+ * @param messages - The orchestration messages to mutate.
+ * @param cacheControl - The cache control directive to apply.
+ * @internal
+ */
+export function applyCacheControlToLastMessage(
+  messages: ChatMessage[],
+  cacheControl: CacheControl
+): void {
+  const lastMessage = messages.at(-1);
+  if (!lastMessage) {
+    return;
+  }
+
+  if (typeof lastMessage.content === 'string') {
+    if (lastMessage.role === 'system' || lastMessage.role === 'tool') {
+      (lastMessage as SystemChatMessage | ToolChatMessage).content = [
+        {
+          type: 'text',
+          text: lastMessage.content,
+          cache_control: cacheControl
+        }
+      ];
+      return;
+    }
+
+    if (lastMessage.role === 'user') {
+      (lastMessage as UserChatMessage).content = [
+        {
+          type: 'text',
+          text: lastMessage.content,
+          cache_control: cacheControl
+        }
+      ];
+    }
+    // Assistant string content has no cacheable block; leave untouched.
+    return;
+  }
+
+  if (!Array.isArray(lastMessage.content)) {
+    return;
+  }
+
+  const isUserMessage = lastMessage.role === 'user';
+  const block = lastMessage.content.findLast(
+    b =>
+      b &&
+      typeof b === 'object' &&
+      (b.type === 'text' ||
+        (isUserMessage && (b.type === 'image_url' || b.type === 'file')))
+  );
+  if (block) {
+    (block as { cache_control?: CacheControl }).cache_control = cacheControl;
+  }
+}
+
+/**
  * Maps {@link MessageToolCalls} to LangChain's {@link ToolCall}.
  * @param toolCalls - The {@link MessageToolCalls} response.
  * @returns The LangChain {@link ToolCall}.
@@ -264,6 +323,36 @@ function mapOrchestrationToLangChainToolCallChunk(
 }
 
 /**
+ * Builds the LangChain `usage_metadata` shape from an orchestration {@link TokenUsage}.
+ * @param usage - The orchestration token usage.
+ * @returns The LangChain `usage_metadata` object.
+ */
+function buildUsageMetadata(usage: TokenUsage): {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  input_token_details?: { cache_read: number; cache_creation: number };
+  output_token_details?: { reasoning: number };
+} {
+  return {
+    input_tokens: usage.prompt_tokens,
+    output_tokens: usage.completion_tokens,
+    total_tokens: usage.total_tokens,
+    ...(usage.prompt_tokens_details && {
+      input_token_details: {
+        cache_read: usage.prompt_tokens_details.cached_tokens ?? 0,
+        cache_creation: usage.prompt_tokens_details.cache_creation_tokens ?? 0
+      }
+    }),
+    ...(usage.completion_tokens_details && {
+      output_token_details: {
+        reasoning: usage.completion_tokens_details.reasoning_tokens ?? 0
+      }
+    })
+  };
+}
+
+/**
  * Maps the completion response to a {@link ChatResult}.
  * @param completionResponse - The completion response to map.
  * @returns The mapped {@link ChatResult}.
@@ -275,6 +364,11 @@ export function mapOutputToChatResult(
   const { final_result, intermediate_results, request_id } = completionResponse;
   const { choices, created, id, model, object, usage, system_fingerprint } =
     final_result;
+  const tokenUsage = {
+    completionTokens: usage?.completion_tokens ?? 0,
+    promptTokens: usage?.prompt_tokens ?? 0,
+    totalTokens: usage?.total_tokens ?? 0
+  };
   return {
     generations: choices.map(choice => ({
       text: choice.message.content ?? '',
@@ -283,11 +377,10 @@ export function mapOutputToChatResult(
         tool_calls: mapOrchestrationToLangChainToolCall(
           choice.message.tool_calls
         ),
-        usage_metadata: {
-          input_tokens: usage?.prompt_tokens ?? 0,
-          output_tokens: usage?.completion_tokens ?? 0,
-          total_tokens: usage?.total_tokens ?? 0
-        }
+        response_metadata: { tokenUsage },
+        usage_metadata: usage
+          ? buildUsageMetadata(usage)
+          : { input_tokens: 0, output_tokens: 0, total_tokens: 0 }
       }),
       additional_kwargs: {
         tool_calls: choice.message.tool_calls,
@@ -306,11 +399,7 @@ export function mapOutputToChatResult(
       model,
       object,
       system_fingerprint,
-      tokenUsage: {
-        completionTokens: usage?.completion_tokens ?? 0,
-        promptTokens: usage?.prompt_tokens ?? 0,
-        totalTokens: usage?.total_tokens ?? 0
-      }
+      tokenUsage
     }
   };
 }
@@ -334,7 +423,7 @@ export function isToolDefinitionLike(
 /**
  * Converts orchestration stream chunk to a LangChain message chunk.
  * @param chunk - The orchestration stream chunk.
- * @returns An {@link AIMessageChunk}
+ * @returns An {@link AIMessageChunk}.
  * @internal
  */
 export function mapOrchestrationChunkToLangChainMessageChunk(
@@ -343,6 +432,7 @@ export function mapOrchestrationChunkToLangChainMessageChunk(
   const choice = chunk._data.final_result?.choices[0];
   const content = chunk.getDeltaContent() ?? '';
   const toolCallChunks = choice?.delta.tool_calls;
+  const usage = chunk.getTokenUsage();
   return new AIMessageChunk({
     content,
     additional_kwargs: {
@@ -351,6 +441,7 @@ export function mapOrchestrationChunkToLangChainMessageChunk(
     },
     ...(toolCallChunks && {
       tool_call_chunks: mapOrchestrationToLangChainToolCallChunk(toolCallChunks)
-    })
+    }),
+    ...(usage && { usage_metadata: buildUsageMetadata(usage) })
   });
 }

--- a/packages/langchain/src/orchestration/util.ts
+++ b/packages/langchain/src/orchestration/util.ts
@@ -17,6 +17,7 @@ import type {
   ChatMessage,
   ChatMessageContent,
   CompletionPostResponse,
+  DeveloperChatMessage,
   FunctionObject,
   MessageToolCalls,
   SystemChatMessage,
@@ -159,27 +160,39 @@ function mapAiMessageToOrchestrationAssistantMessage(
     message.additional_kwargs.tool_calls;
   return {
     ...(tool_calls?.length ? { tool_calls } : {}),
-    content: message.content,
+    content: cloneMessageContent(message.content),
     role: 'assistant'
   } as AssistantChatMessage;
 }
 
-function mapHumanMessageToChatMessage(message: HumanMessage): UserChatMessage {
-  if (Array.isArray(message.content)) {
-    message.content = message.content.map(content => ({
-      ...content,
-      ...(content.type === 'image_url' && typeof content.image_url === 'string'
-        ? {
-            image_url: {
-              url: content.image_url
-            }
-          }
-        : {})
-    }));
+function cloneMessageContent<TContent>(content: TContent): TContent {
+  if (!Array.isArray(content)) {
+    return content;
   }
+
+  // Shallow-clone blocks so cache_control mutations never touch caller-owned messages.
+  return content.map(block =>
+    block && typeof block === 'object' ? { ...block } : block
+  ) as TContent;
+}
+
+function mapHumanMessageToChatMessage(message: HumanMessage): UserChatMessage {
+  const content = Array.isArray(message.content)
+    ? message.content.map(item => ({
+        ...item,
+        ...(item.type === 'image_url' && typeof item.image_url === 'string'
+          ? {
+              image_url: {
+                url: item.image_url
+              }
+            }
+          : {})
+      }))
+    : message.content;
+
   return {
     role: 'user',
-    content: message.content
+    content
   } as UserChatMessage;
 }
 
@@ -196,7 +209,7 @@ function mapSystemMessageToOrchestrationSystemMessage(
   }
   return {
     role: 'system',
-    content: message.content as ChatMessageContent
+    content: cloneMessageContent(message.content) as ChatMessageContent
   };
 }
 
@@ -213,7 +226,7 @@ function mapToolMessageToOrchestrationToolMessage(
   }
   return {
     role: 'tool',
-    content: message.content as ChatMessageContent,
+    content: cloneMessageContent(message.content) as ChatMessageContent,
     tool_call_id: message.tool_call_id
   };
 }
@@ -246,8 +259,15 @@ export function applyCacheControlToLastMessage(
   }
 
   if (typeof lastMessage.content === 'string') {
-    if (lastMessage.role === 'system' || lastMessage.role === 'tool') {
-      (lastMessage as SystemChatMessage | ToolChatMessage).content = [
+    if (
+      lastMessage.role === 'system' ||
+      lastMessage.role === 'tool' ||
+      lastMessage.role === 'developer'
+    ) {
+      (
+        lastMessage as
+          SystemChatMessage | ToolChatMessage | DeveloperChatMessage
+      ).content = [
         {
           type: 'text',
           text: lastMessage.content,
@@ -334,6 +354,8 @@ function buildUsageMetadata(usage: TokenUsage): {
   input_token_details?: { cache_read: number; cache_creation: number };
   output_token_details?: { reasoning: number };
 } {
+  const reasoning = usage.completion_tokens_details?.reasoning_tokens;
+
   return {
     input_tokens: usage.prompt_tokens,
     output_tokens: usage.completion_tokens,
@@ -344,10 +366,8 @@ function buildUsageMetadata(usage: TokenUsage): {
         cache_creation: usage.prompt_tokens_details.cache_creation_tokens ?? 0
       }
     }),
-    ...(usage.completion_tokens_details && {
-      output_token_details: {
-        reasoning: usage.completion_tokens_details.reasoning_tokens ?? 0
-      }
+    ...(reasoning !== undefined && {
+      output_token_details: { reasoning }
     })
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1341,27 +1341,27 @@ packages:
     resolution: {integrity: sha512-nWJXMdM0Pcx/ipM2+5BvSciQKyCc0LAAO+acCOAQp65SA4HEQ2Odp9yxidY4ijW42TVp3fSMBvGwVjbWWx9Uew==}
 
   '@sap/cds-compiler@6.9.3':
-    resolution: {integrity: sha512-8fEeM6D059ruqLWoJqzFSNLkGoUCMnycx7Zv4OP4nA9zZeHzFC3nAe6s3ak2kASSiub1xAMMPzDE/9EnSXQKLw==, tarball: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@sap/cds-compiler/-/@sap/cds-compiler-6.9.3.tgz}
+    resolution: {integrity: sha512-8fEeM6D059ruqLWoJqzFSNLkGoUCMnycx7Zv4OP4nA9zZeHzFC3nAe6s3ak2kASSiub1xAMMPzDE/9EnSXQKLw==}
     engines: {node: '>=20'}
     hasBin: true
 
   '@sap/cds-dk@9.9.3':
-    resolution: {integrity: sha512-XQAtj8g3NR8CNtrZ+eUB0aZNj+hAccWu7h8fE2ViB2oI4tLF6Li3SZSeRP+sDa5zz7hKi6W8XN9R8DgzCy1A4g==, tarball: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@sap/cds-dk/-/@sap/cds-dk-9.9.3.tgz}
+    resolution: {integrity: sha512-XQAtj8g3NR8CNtrZ+eUB0aZNj+hAccWu7h8fE2ViB2oI4tLF6Li3SZSeRP+sDa5zz7hKi6W8XN9R8DgzCy1A4g==}
     hasBin: true
 
   '@sap/cds-fiori@2.3.0':
-    resolution: {integrity: sha512-6oWov+DSpFrSTgxXR0dZhak6aZ/IVRZvaHERMi0EgSTzIJdlvZlpw3Kf18ePMcTrRrtEXwD4RIjKt8pbs0g2Hg==, tarball: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@sap/cds-fiori/-/@sap/cds-fiori-2.3.0.tgz}
+    resolution: {integrity: sha512-6oWov+DSpFrSTgxXR0dZhak6aZ/IVRZvaHERMi0EgSTzIJdlvZlpw3Kf18ePMcTrRrtEXwD4RIjKt8pbs0g2Hg==}
     peerDependencies:
       '@sap/cds': '>=8'
 
   '@sap/cds-mtxs@3.9.4':
-    resolution: {integrity: sha512-A3FRCGCMNhml8MLpGv+OUHwDhAUgvAiE38qdTL87/KQ932CTNZ1frohQtT24iszoamB7NI8lp9RR3BFD6HR/FQ==, tarball: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@sap/cds-mtxs/-/@sap/cds-mtxs-3.9.4.tgz}
+    resolution: {integrity: sha512-A3FRCGCMNhml8MLpGv+OUHwDhAUgvAiE38qdTL87/KQ932CTNZ1frohQtT24iszoamB7NI8lp9RR3BFD6HR/FQ==}
     hasBin: true
     peerDependencies:
       '@sap/cds': '>=9'
 
   '@sap/cds@9.9.1':
-    resolution: {integrity: sha512-GqdsBsRkZThhpOyzj8ihf/jDmf/2zprZFgaun6ZymUw4/ahzjK/bbdd6eQ8txDuv88pnUl2HPFjvUVq3O/6hCA==, tarball: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@sap/cds/-/@sap/cds-9.9.1.tgz}
+    resolution: {integrity: sha512-GqdsBsRkZThhpOyzj8ihf/jDmf/2zprZFgaun6ZymUw4/ahzjK/bbdd6eQ8txDuv88pnUl2HPFjvUVq3O/6hCA==}
     engines: {node: '>=20'}
     hasBin: true
     peerDependencies:
@@ -1400,11 +1400,11 @@ packages:
     engines: {node: ^20.0.0  || ^22.0.0 || ^24.0.0}
 
   '@sap/xssec@4.13.0':
-    resolution: {integrity: sha512-8e+bU+OyAIpAGXQanOopZa5YEK+yHKw84dhhihcCotF40MSNFbVHjQ4xM5hf4QndlqDGfXIuvXmoOMuDATa/gA==, tarball: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@sap/xssec/-/@sap/xssec-4.13.0.tgz}
+    resolution: {integrity: sha512-8e+bU+OyAIpAGXQanOopZa5YEK+yHKw84dhhihcCotF40MSNFbVHjQ4xM5hf4QndlqDGfXIuvXmoOMuDATa/gA==}
     engines: {node: '>=18'}
 
   '@sap/xssec@4.13.1':
-    resolution: {integrity: sha512-sZwTvxO7Vh5qjrSXHgb0fTJEPz14kYPzScn4GI5kZYGb97fZ4X5IE90mlafjZeJFfQkBCCIzVWfrbweCpBbPyQ==, tarball: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@sap/xssec/-/@sap/xssec-4.13.1.tgz}
+    resolution: {integrity: sha512-sZwTvxO7Vh5qjrSXHgb0fTJEPz14kYPzScn4GI5kZYGb97fZ4X5IE90mlafjZeJFfQkBCCIzVWfrbweCpBbPyQ==}
     engines: {node: '>=18'}
 
   '@scalar/helpers@0.9.0':

--- a/sample-code/src/tutorials/mcp/weather-mcp-server.ts
+++ b/sample-code/src/tutorials/mcp/weather-mcp-server.ts
@@ -29,6 +29,13 @@ function buildForecastUrl(latitude: unknown, longitude: unknown): string {
   return url.toString();
 }
 
+interface GeocodingResponse {
+  results?: {
+    latitude: number;
+    longitude: number;
+  }[];
+}
+
 const server = new McpServer({
   name: 'Open-Meteo Weather MCP Server',
   version: '1.0.0'
@@ -48,7 +55,7 @@ server.registerTool(
     try {
       const geoUrl = buildGeocodingUrl(city);
       const geoResponse = await fetch(geoUrl);
-      const data = await geoResponse.json();
+      const data = (await geoResponse.json()) as GeocodingResponse;
 
       if (!data.results?.length) {
         return {

--- a/styles/config/vocabularies/SAP/accept.txt
+++ b/styles/config/vocabularies/SAP/accept.txt
@@ -147,3 +147,4 @@ SDKs
 JSDoc
 impr
 [Oo]pen[Aa][Ii]
+breakpoints?

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,7 @@
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
+    "lib": ["ES2024"],
     "types": ["node"]
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
-    "lib": ["ES2024"],
+    "lib": ["es2024"],
     "types": ["node"]
   }
 }


### PR DESCRIPTION
## Context

…adata

Split from https://github.com/SAP/ai-sdk-js/pull/1950
Part of https://github.com/SAP/ai-sdk-js-backlog/issues/575

- Add `cache_control` call option to `OrchestrationCallOptions` that automatically places a cache breakpoint on the last cacheable content block of the last message in both invoke and stream paths.
- Expose `cached_tokens` and `cache_creation_tokens` via LangChain's `usage_metadata.input_token_details` for orchestration responses.
- Extract `buildUsageMetadata` helper for non-streaming and streaming token usage mapping; add `response_metadata.tokenUsage` to match LangChain conventions.

## What this PR does and why it is needed

<!-- Please provide a description summarizing your changes and their rationale -->

<!-- Before raising this PR, please review the Definition of Done below and confirm that all applicable items are completed. 
## Definition of Done

- [ ] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [ ] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code 
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated -->
