### PR TITLE
chore: add .d.ts files to sonar exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,4 +27,5 @@ sonar.coverage.exclusions=\
   **/*.yml,\
   **/*.yaml,\
   **/*.json,\
-  **/*.py
+  **/*.py, \
+  **/*.d.ts


### PR DESCRIPTION
.d.ts files that are not under dist are our test files and do not require coverage. they ARE coverage 😊 