### PR TITLE
chore: tiny refactoring

### DIFF
--- a/packages/orchestration/src/util/module-config.ts
+++ b/packages/orchestration/src/util/module-config.ts
@@ -79,7 +79,7 @@ export function constructCompletionPostRequestFromConfigReference(
     ...(request?.placeholderValues && {
       placeholder_values: request.placeholderValues
     }),
-    ...(messagesHistory && {
+    ...(messagesHistory?.length && {
       messages_history: messagesHistory
     })
   } as

--- a/packages/orchestration/src/util/module-config.ts
+++ b/packages/orchestration/src/util/module-config.ts
@@ -69,9 +69,10 @@ export function constructCompletionPostRequestFromConfigReference(
   | CompletionRequestConfigurationReferenceByNameScenarioVersion {
   // Route request.messages into messages_history since there is no local
   // prompt.template to merge them into for config references.
-  const messagesHistory = request?.messages?.length
-    ? [...(request.messagesHistory || []), ...request.messages]
-    : request?.messagesHistory;
+  const messagesHistory = [
+    ...(request?.messagesHistory || []),
+    ...(request?.messages || [])
+  ];
 
   return {
     config_ref: configRef,

--- a/packages/orchestration/src/util/module-config.ts
+++ b/packages/orchestration/src/util/module-config.ts
@@ -79,7 +79,7 @@ export function constructCompletionPostRequestFromConfigReference(
     ...(request?.placeholderValues && {
       placeholder_values: request.placeholderValues
     }),
-    ...(messagesHistory?.length && {
+    ...(messagesHistory.length && {
       messages_history: messagesHistory
     })
   } as


### PR DESCRIPTION
I noticed that this could be simplified. However, if `messagesHistory` was `undefined` it would now be `[]`.