### PR TITLE
feat: PoC support sap-rpt-1.5 (don't merge)

### DIFF
--- a/packages/document-grounding/src/client/api/retrieval-api.ts
+++ b/packages/document-grounding/src/client/api/retrieval-api.ts
@@ -38,14 +38,14 @@ export const RetrievalApi = {
   /**
    * List data repository by id
    * @param repositoryId - Repository ID
-   * @param headerParameters - Object containing the following keys: AI-Resource-Group.
    * @param queryParameters - Object containing the following keys: remoteName.
+   * @param headerParameters - Object containing the following keys: AI-Resource-Group.
    * @returns The request builder, use the `execute()` method to trigger the request.
    */
   getDataRepositoryById: (
     repositoryId: string,
-    headerParameters: { 'AI-Resource-Group': string },
-    queryParameters: { remoteName?: string }
+    queryParameters: { remoteName?: string },
+    headerParameters: { 'AI-Resource-Group': string }
   ) =>
     new OpenApiRequestBuilder<DataRepository>(
       'get',

--- a/packages/prompt-registry/src/client/prompt-registry/prompt-templates-api.ts
+++ b/packages/prompt-registry/src/client/prompt-registry/prompt-templates-api.ts
@@ -79,19 +79,19 @@ export const PromptTemplatesApi = {
    * @param scenario - Path parameter.
    * @param version - Path parameter.
    * @param name - Path parameter.
-   * @param headerParameters - Object containing the following keys: AI-Resource-Group, AI-Resource-Group-Scope.
    * @param queryParameters - Object containing the following keys: $top, $skip.
+   * @param headerParameters - Object containing the following keys: AI-Resource-Group, AI-Resource-Group-Scope.
    * @returns The request builder, use the `execute()` method to trigger the request.
    */
   listPromptTemplateHistory: (
     scenario: string,
     version: string,
     name: string,
+    queryParameters?: { $top?: number; $skip?: number },
     headerParameters?: {
       'AI-Resource-Group'?: string;
       'AI-Resource-Group-Scope'?: 'true' | 'True' | 'false' | 'False';
-    },
-    queryParameters?: { $top?: number; $skip?: number }
+    }
   ) =>
     new OpenApiRequestBuilder<PromptTemplateListResponse>(
       'get',

--- a/packages/rpt/package.json
+++ b/packages/rpt/package.json
@@ -37,7 +37,7 @@
     "test": "vitest run",
     "lint": "oxlint && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -c",
     "lint:fix": "oxlint --fix && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --log-level error",
-    "generate": "openapi-generator --generateESM --clearOutputDir -i ./src/spec/rpt.json -o ./src/client",
+    "generate": "node /Users/[redacted]/Dev/cloud-sdk-js/packages/openapi-generator/dist/cli.js --generateESM --clearOutputDir -i ./src/spec/rpt.json -o ./src/client",
     "postgenerate": "pnpm update-imports && pnpm make-rpt-internal && pnpm lint:fix",
     "update-imports": "node ../../scripts/update-imports.ts ./src/client/rpt",
     "make-rpt-internal": "node ../../scripts/postgenerate-rpt.ts ./src/client/rpt/rpt-api.ts",

--- a/packages/rpt/src/client.ts
+++ b/packages/rpt/src/client.ts
@@ -132,11 +132,11 @@ export class RptClient {
     const body = {
       data_schema: dataSchema
         ? Object.fromEntries(
-          dataSchema.map(({ name, ...schemaFieldConfig }) => [
-            name,
-            schemaFieldConfig
-          ])
-        )
+            dataSchema.map(({ name, ...schemaFieldConfig }) => [
+              name,
+              schemaFieldConfig
+            ])
+          )
         : null,
       ...predictionData
     } satisfies PredictRequestPayload;

--- a/packages/rpt/src/client.ts
+++ b/packages/rpt/src/client.ts
@@ -32,7 +32,7 @@ export class RptClient {
    * @param destination - The destination to use for the request.
    */
   constructor(
-    modelDeployment: ModelDeployment<SapRptModel> = 'sap-rpt-1-small',
+    modelDeployment: ModelDeployment<SapRptModel> = 'sap-rpt-1.5',
     destination?: HttpDestinationOrFetchOptions
   ) {
     this.modelDeployment = modelDeployment;
@@ -100,7 +100,12 @@ export class RptClient {
     const { resourceGroup, deploymentId } =
       await this.getResourceGroupAndDeploymentId();
 
-    return RptApi.predictParquet({ ...payload, file })
+    return RptApi.predictParquet({
+      ...payload,
+      file,
+      // TODO: Remote server seems to accept both JSON string and real object.
+      prediction_config: payload.prediction_config as any
+    })
       .setBasePath(`/inference/deployments/${deploymentId}`)
       .addCustomHeaders({
         'ai-resource-group': resourceGroup || 'default'
@@ -127,11 +132,11 @@ export class RptClient {
     const body = {
       data_schema: dataSchema
         ? Object.fromEntries(
-            dataSchema.map(({ name, ...schemaFieldConfig }) => [
-              name,
-              schemaFieldConfig
-            ])
-          )
+          dataSchema.map(({ name, ...schemaFieldConfig }) => [
+            name,
+            schemaFieldConfig
+          ])
+        )
         : null,
       ...predictionData
     } satisfies PredictRequestPayload;

--- a/packages/rpt/src/client/rpt/rpt-api.ts
+++ b/packages/rpt/src/client/rpt/rpt-api.ts
@@ -17,24 +17,40 @@ import type {
 export const RptApi = {
   _defaultBasePath: undefined,
   /**
-   * Make in-context predictions for specified target columns.
-   * Either "rows" or "columns" must be provided and must contain both context and query rows.
-   * You can optionally send gzip-compressed JSON payloads and set a "Content-Encoding: gzip" header.
-   * @param body - Request body.
+   * Create a request builder for execution of get requests to the '/health' endpoint.
    * @returns The request builder, use the `execute()` method to trigger the request.
    */
-  predict: (body: PredictRequestPayload) =>
+  health: () =>
+    new OpenApiRequestBuilder<any>(
+      'get',
+      '/health',
+      {},
+      RptApi._defaultBasePath
+    ),
+  /**
+   * Create a request builder for execution of post requests to the '/predict' endpoint.
+   * @param body - Request body.
+   * @param headerParameters - Object containing the following keys: Content-Encoding.
+   * @returns The request builder, use the `execute()` method to trigger the request.
+   */
+  predict: (
+    body: PredictRequestPayload,
+    headerParameters?: { 'Content-Encoding'?: 'gzip' }
+  ) =>
     new OpenApiRequestBuilder<PredictResponsePayload>(
       'post',
       '/predict',
       {
         body,
-        headerParameters: { 'content-type': 'application/json' }
+        headerParameters: {
+          'content-type': 'application/json',
+          ...headerParameters
+        }
       },
       RptApi._defaultBasePath
     ),
   /**
-   * Make in-context predictions for specified target columns based on provided table data Parquet file.
+   * Create a request builder for execution of post requests to the '/predict_parquet' endpoint.
    * @param body - Request body.
    * @returns The request builder, use the `execute()` method to trigger the request.
    */
@@ -46,25 +62,25 @@ export const RptApi = {
         body,
         _encoding: {
           prediction_config: {
-            contentType: 'application/json',
+            contentType: 'text/plain',
             isImplicit: true,
-            parsedContentTypes: [{ parameters: {}, type: 'application/json' }]
+            parsedContentTypes: [{ type: 'text/plain', parameters: {} }]
           },
           index_column: {
             contentType: 'text/plain',
             isImplicit: true,
-            parsedContentTypes: [{ parameters: {}, type: 'text/plain' }]
+            parsedContentTypes: [{ type: 'text/plain', parameters: {} }]
           },
           parse_data_types: {
             contentType: 'text/plain',
             isImplicit: true,
-            parsedContentTypes: [{ parameters: {}, type: 'text/plain' }]
+            parsedContentTypes: [{ type: 'text/plain', parameters: {} }]
           },
           file: {
             contentType: 'application/vnd.apache.parquet',
             isImplicit: false,
             parsedContentTypes: [
-              { parameters: {}, type: 'application/vnd.apache.parquet' }
+              { type: 'application/vnd.apache.parquet', parameters: {} }
             ]
           }
         },

--- a/packages/rpt/src/client/rpt/schema/body-predict-parquet.ts
+++ b/packages/rpt/src/client/rpt/schema/body-predict-parquet.ts
@@ -3,24 +3,21 @@
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
-import type { PredictionConfig } from './prediction-config.js';
+
 /**
  * Representation of the 'BodyPredictParquet' schema.
  */
 export type BodyPredictParquet = {
   /**
-   * Parquet file containing the data
-   * Format: "binary".
+   * Content Media Type: "application/vnd.apache.parquet".
    */
   file: Blob;
-  prediction_config: PredictionConfig;
   /**
-   * Optional index column name
+   * JSON string containing the prediction configuration (see PredictionConfig schema).
+   * @example "{\"target_columns\":[{\"name\": \"PRICE\",\"prediction_placeholder\": null,\"task_type\": \"regression\"}]}"
+   * Content Media Type: "application/json".
    */
+  prediction_config: string;
   index_column?: string;
-  /**
-   * Whether to parse data types
-   * Default: true.
-   */
   parse_data_types?: boolean;
 } & Record<string, any>;

--- a/packages/rpt/src/client/rpt/schema/column-type.ts
+++ b/packages/rpt/src/client/rpt/schema/column-type.ts
@@ -5,6 +5,27 @@
  */
 
 /**
- * Representation of the 'ColumnType' schema.
+ * Supported column data types for the data schema.
+ *
+ * Includes base types (string, numeric, date) and additional types
+ * derived from SAP CDS (https://cap.cloud.sap/docs/cds/types#core-built-in-types).
+ * Additional types are mapped to the corresponding base type internally.
+ * All values are lowercase for case-insensitive matching.
  */
-export type ColumnType = 'string' | 'numeric' | 'date';
+export type ColumnType =
+  | 'string'
+  | 'numeric'
+  | 'date'
+  | 'boolean'
+  | 'largestring'
+  | 'uuid'
+  | 'integer'
+  | 'int16'
+  | 'int32'
+  | 'int64'
+  | 'uint8'
+  | 'decimal'
+  | 'double'
+  | 'time'
+  | 'datetime'
+  | 'timestamp';

--- a/packages/rpt/src/client/rpt/schema/explanation-config.ts
+++ b/packages/rpt/src/client/rpt/schema/explanation-config.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 SAP SE or an SAP affiliate company. All rights reserved.
+ *
+ * This is a generated file powered by the SAP Cloud SDK for JavaScript.
+ */
+
+/**
+ * Configuration for explainability outputs.
+ */
+export type ExplanationConfig = {
+  /**
+   * For how many columns to output column scores (optional, default is 0). 0 by default (no explainability). Max value is 20.
+   * Maximum: 20.
+   */
+  top_column_scores?: number;
+  /**
+   * For how many context rows to return indices per query row (optional, default is 0). 0 by default (no explainability). Max value is 20.
+   * Maximum: 20.
+   */
+  top_relevant_context_rows?: number;
+};

--- a/packages/rpt/src/client/rpt/schema/explanation-result.ts
+++ b/packages/rpt/src/client/rpt/schema/explanation-result.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 SAP SE or an SAP affiliate company. All rights reserved.
+ *
+ * This is a generated file powered by the SAP Cloud SDK for JavaScript.
+ */
+
+/**
+ * Explanation data for predictions.
+ */
+export type ExplanationResult = {
+  /**
+   * Column scores per query row extracted from the model (higher means more weight was put on this column).
+   */
+  top_column_scores?: Record<string, number>[] | null;
+  /**
+   * 2D array where each subarray contains indices of most relevant context rows for that query row. The first dimension indexes query rows, the second dimension indexes all rows as a sequential integer index.
+   */
+  top_relevant_context_rows?: number[][] | null;
+} & Record<string, any>;

--- a/packages/rpt/src/client/rpt/schema/index.ts
+++ b/packages/rpt/src/client/rpt/schema/index.ts
@@ -4,11 +4,13 @@
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
 export * from './body-predict-parquet.js';
+export * from './explanation-result.js';
 export * from './predict-response-metadata.js';
 export * from './predict-response-payload.js';
 export * from './predict-response-status.js';
 export * from './prediction-result.js';
 export * from './column-type.js';
+export * from './explanation-config.js';
 export * from './prediction-config.js';
 export * from './schema-field-config.js';
 export * from './target-column-config.js';

--- a/packages/rpt/src/client/rpt/schema/predict-request-payload.ts
+++ b/packages/rpt/src/client/rpt/schema/predict-request-payload.ts
@@ -6,33 +6,52 @@
 import type { PredictionConfig } from './prediction-config.js';
 import type { SchemaFieldConfig } from './schema-field-config.js';
 /**
- * Users need to specify a list of rows, which contains both the context rows
- * and the rows for which to predict a label, and a mapping of column names
- * to placeholder values. The model will predict the value for any column
- * specified in `predict_columns` for all rows that have the placeholder
- * value in that column.
+ * Users need to specify a list of rows, which contains both the context rows and the rows for which to predict a label, and a mapping of column names to placeholder values. The model will predict the value for any column specified in `target_columns` for all rows that have the prediction placeholder in that column. Either "rows" or "columns" must be provided, but not both.
  */
-export type PredictRequestPayload = {
-  prediction_config: PredictionConfig;
-  /**
-   * Table rows, i.e. list of objects where each object is a mapping of column names to values. Either "rows" or "columns" must be provided.
-   */
-  rows?: Record<string, string | number | number | null>[];
-  /**
-   * Alternative to rows: columns of data where each key is a column name and the value is a list of all column values. Either "rows" or "columns" must be provided.
-   */
-  columns?: Record<string, (string | number | number | null)[]> | null;
-  /**
-   * The name of the index column. If provided, the service will return this column's value in each prediction object to facilitate aligning the output predictions with the input rows on the client side. If not provided, the column will not be included in the output.
-   */
-  index_column?: string | null;
-  /**
-   * Whether to parse the data types of the columns. If set to True, numeric columns will be parsed to float or integer and dates in ISO format YYYY-MM-DD will be parsed.
-   * Default: true.
-   */
-  parse_data_types?: boolean;
-  /**
-   * Optional schema defining the data types of each column. If provided, this will override automatic data type parsing.
-   */
-  data_schema?: Record<string, SchemaFieldConfig> | null;
-};
+export type PredictRequestPayload =
+  | {
+      /**
+       * Configuration of target columns and placeholder value.
+       */
+      prediction_config: PredictionConfig;
+      /**
+       * The name of the index column. If provided, the service will return this column's value in each prediction object to facilitate aligning the output predictions with the input rows on the client side. If not provided, the column will not be included in the output.
+       */
+      index_column?: string | null;
+      /**
+       * Whether to parse the data types of the columns. If set to True, numeric columns will be parsed to float or integer and dates in ISO format YYYY-MM-DD will be parsed.
+       * Default: true.
+       */
+      parse_data_types?: boolean;
+      /**
+       * Optional schema defining the data types of each column. If provided, this will override automatic data type parsing.
+       */
+      data_schema?: Record<string, SchemaFieldConfig> | null;
+      /**
+       * Table rows, i.e. list of objects where each object is a mapping of column names to values. Either "rows" or "columns" must be provided.
+       */
+      rows: Record<string, string | number | number | null>[];
+    }
+  | {
+      /**
+       * Configuration of target columns and placeholder value.
+       */
+      prediction_config: PredictionConfig;
+      /**
+       * The name of the index column. If provided, the service will return this column's value in each prediction object to facilitate aligning the output predictions with the input rows on the client side. If not provided, the column will not be included in the output.
+       */
+      index_column?: string | null;
+      /**
+       * Whether to parse the data types of the columns. If set to True, numeric columns will be parsed to float or integer and dates in ISO format YYYY-MM-DD will be parsed.
+       * Default: true.
+       */
+      parse_data_types?: boolean;
+      /**
+       * Optional schema defining the data types of each column. If provided, this will override automatic data type parsing.
+       */
+      data_schema?: Record<string, SchemaFieldConfig> | null;
+      /**
+       * Alternative to rows: columns of data where each key is a column name and the value is a list of all column values. Either "rows" or "columns" must be provided.
+       */
+      columns: Record<string, (string | number | number | null)[]>;
+    };

--- a/packages/rpt/src/client/rpt/schema/predict-response-payload.ts
+++ b/packages/rpt/src/client/rpt/schema/predict-response-payload.ts
@@ -5,6 +5,7 @@
  */
 import type { PredictResponseStatus } from './predict-response-status.js';
 import type { PredictionResult } from './prediction-result.js';
+import type { ExplanationResult } from './explanation-result.js';
 import type { PredictResponseMetadata } from './predict-response-metadata.js';
 /**
  * Response payload for prediction requests.
@@ -15,10 +16,17 @@ export type PredictResponsePayload = {
    * Unique ID for the request.
    */
   id: string;
+  /**
+   * Status message that can indicate warnings (e.g. about suboptimal data).
+   */
   status: PredictResponseStatus;
   /**
    * Mapping of column names to their list of prediction results or index column.
    */
   predictions: Record<string, PredictionResult[] | string | number>[];
+  /**
+   * Explanation data containing context row and column scores.
+   */
+  explanations?: ExplanationResult | null;
   metadata: PredictResponseMetadata;
 };

--- a/packages/rpt/src/client/rpt/schema/predict-response-status.ts
+++ b/packages/rpt/src/client/rpt/schema/predict-response-status.ts
@@ -9,7 +9,7 @@
  */
 export type PredictResponseStatus = {
   /**
-   * Status code (zero means success, other status codes indicate warnings)
+   * Status code (zero means success, other status codes indicate warnings or errors)
    */
   code: number;
   /**

--- a/packages/rpt/src/client/rpt/schema/prediction-config.ts
+++ b/packages/rpt/src/client/rpt/schema/prediction-config.ts
@@ -4,9 +4,14 @@
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */
 import type { TargetColumnConfig } from './target-column-config.js';
+import type { ExplanationConfig } from './explanation-config.js';
 /**
  * Configuration of the prediction model.
  */
 export type PredictionConfig = {
   target_columns: TargetColumnConfig[];
+  /**
+   * Optional configuration for explainability outputs (column scores and relevant context rows).
+   */
+  explanations?: ExplanationConfig;
 };

--- a/packages/rpt/src/client/rpt/schema/prediction-result.ts
+++ b/packages/rpt/src/client/rpt/schema/prediction-result.ts
@@ -9,11 +9,15 @@
  */
 export type PredictionResult = {
   /**
-   * The predicted value for the column.
+   * The predicted value for the column (string for classification, number for regression).
    */
   prediction: string | number;
   /**
-   * The confidence of the prediction (currently not provided).
+   * The confidence of the prediction (null for regression predictions).
    */
   confidence?: number | null;
+  /**
+   * Lower and upper bounds of the prediction confidence interval (null for classification predictions).
+   */
+  confidence_interval?: [number, number] | null;
 } & Record<string, any>;

--- a/packages/rpt/src/client/rpt/schema/schema-field-config.ts
+++ b/packages/rpt/src/client/rpt/schema/schema-field-config.ts
@@ -8,5 +8,8 @@ import type { ColumnType } from './column-type.js';
  * Configuration for a single field in the input data schema.
  */
 export type SchemaFieldConfig = {
+  /**
+   * The data type of the column. Supports base types (string, numeric, date) and extended types (e.g., Boolean, Integer, Timestamp). Extended types are mapped to corresponding base types internally. Case-insensitive.
+   */
   dtype: ColumnType;
-} & Record<string, any>;
+};

--- a/packages/rpt/src/client/rpt/schema/target-column-config.ts
+++ b/packages/rpt/src/client/rpt/schema/target-column-config.ts
@@ -15,13 +15,13 @@ export type TargetColumnConfig = {
   /**
    * The placeholder value in any column for which to predict a value. The model will predict a value for all table cells containing this value.
    */
-  prediction_placeholder: string | number;
+  prediction_placeholder: string | number | null;
   /**
    * The type of prediction task for this column. If not provided, the model will infer the task type from the data.
    */
   task_type?: 'classification' | 'regression' | null;
   /**
-   * How many predictions to output per classification column.If not provided, only a single prediction is returned. Only relevant for classification.
+   * How many predictions to output for this classification column.If not provided, only a single prediction is returned. Only relevant for classification.
    */
   top_k?: number | null;
-} & Record<string, any>;
+};

--- a/packages/rpt/src/spec/rpt.json
+++ b/packages/rpt/src/spec/rpt.json
@@ -1,25 +1,204 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "SAP-RPT-1 Tabular AI",
-    "description": "A REST API for in-context learning with the SAP-RPT-1 model.",
-    "version": "0.1.0",
-    "x-logo": {
-      "url": "https://www.sap.com/favicon.ico"
-    }
+    "title": "SAP RPT",
+    "description": "A REST API for in-context learning with SAP RPT models.",
+    "version": "1.5.0"
   },
   "servers": [
     {
-      "url": "/v1"
+      "url": "/"
     }
   ],
   "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health Check",
+        "operationId": "health",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/predict": {
       "post": {
-        "summary": "Make in-context predictions for specified target columns based on provided table data JSON (optionally gzip-compressed).",
-        "description": "Make in-context predictions for specified target columns.\nEither \"rows\" or \"columns\" must be provided and must contain both context and query rows.\nYou can optionally send gzip-compressed JSON payloads and set a \"Content-Encoding: gzip\" header.",
+        "summary": "Make predictions from JSON (optionally gzip-compressed).",
         "operationId": "predict",
+        "responses": {
+          "200": {
+            "description": "Successful Prediction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictResponsePayload"
+                },
+                "example": {
+                  "id": "781bf15e-602a-4503-a8ff-dc32b20f804a",
+                  "status": {
+                    "code": 0,
+                    "message": "ok"
+                  },
+                  "predictions": [
+                    {
+                      "COSTCENTER": [
+                        {
+                          "prediction": "Office Furniture",
+                          "confidence": 0.52
+                        }
+                      ],
+                      "PRICE": [
+                        {
+                          "prediction": 195.09017944335938,
+                          "confidence_interval": [191.4201023, 198.7602565]
+                        }
+                      ],
+                      "ID": "35"
+                    },
+                    {
+                      "COSTCENTER": [
+                        {
+                          "prediction": "Data Infrastructure",
+                          "confidence": 1
+                        }
+                      ],
+                      "PRICE": [
+                        {
+                          "prediction": 209.38052368164062,
+                          "confidence_interval": [198.182501013, 220.57854635]
+                        }
+                      ],
+                      "ID": "104"
+                    }
+                  ],
+                  "explanations": {
+                    "top_column_scores": [
+                      {
+                        "PRODUCT": 0.08,
+                        "ORDERDATE": 0.03
+                      },
+                      {
+                        "PRODUCT": 0.07,
+                        "ORDERDATE": 0.02
+                      }
+                    ],
+                    "top_relevant_context_rows": [
+                      [3, 4, 1],
+                      [2, 1, 4]
+                    ]
+                  },
+                  "metadata": {
+                    "num_columns": 5,
+                    "num_rows": 2,
+                    "num_predictions": 4,
+                    "num_query_rows": 2
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid input data",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": {
+                    "code": 2,
+                    "message": "Invalid input"
+                  },
+                  "detail": [
+                    {
+                      "loc": ["body", "prediction_config"],
+                      "msg": "Field required",
+                      "type": "missing"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload Too Large",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": {
+                    "code": 2,
+                    "message": "Invalid input"
+                  },
+                  "detail": [
+                    {
+                      "loc": [],
+                      "msg": "Request body too large (>576716800 bytes)",
+                      "type": "value_error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": {
+                    "code": 2,
+                    "message": "Invalid input"
+                  },
+                  "detail": [
+                    {
+                      "loc": ["body", "prediction_config"],
+                      "msg": "Field required",
+                      "type": "value_error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": {
+                    "code": 3,
+                    "message": "Internal server error"
+                  },
+                  "detail": []
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": {
+                    "code": 4,
+                    "message": "Server under high load, please try again later"
+                  },
+                  "detail": []
+                }
+              }
+            }
+          }
+        },
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -36,7 +215,8 @@
                         {
                           "name": "category",
                           "prediction_placeholder": "?",
-                          "task_type": "classification"
+                          "task_type": "classification",
+                          "top_k": 1
                         }
                       ]
                     },
@@ -73,7 +253,7 @@
                 },
                 "regression_example": {
                   "summary": "Regression Example",
-                  "description": "Predict multiple columns including regression using in-context learning",
+                  "description": "Predict multiple columns including regression using in-context learning (note that you can also use null or numeric values as placeholders)",
                   "value": {
                     "index_column": "ID",
                     "prediction_config": {
@@ -133,148 +313,25 @@
                 }
               }
             }
-          },
-          "required": true
+          }
         },
-        "responses": {
-          "200": {
-            "description": "Successful Prediction",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PredictResponsePayload"
-                },
-                "example": {
-                  "id": "781bf15e-602a-4503-a8ff-dc32b20f804a",
-                  "status": {
-                    "code": 0,
-                    "message": "ok"
-                  },
-                  "predictions": [
-                    {
-                      "COSTCENTER": [
-                        {
-                          "prediction": "Office Furniture",
-                          "confidence": 0.52
-                        }
-                      ],
-                      "PRICE": [
-                        {
-                          "prediction": 195.090179443359
-                        }
-                      ],
-                      "ID": "35"
-                    },
-                    {
-                      "COSTCENTER": [
-                        {
-                          "prediction": "Data Infrastructure",
-                          "confidence": 1
-                        }
-                      ],
-                      "PRICE": [
-                        {
-                          "prediction": 209.380523681641
-                        }
-                      ],
-                      "ID": "104"
-                    }
-                  ],
-                  "metadata": {
-                    "num_columns": 5,
-                    "num_rows": 2,
-                    "num_predictions": 4,
-                    "num_query_rows": 2
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request - Invalid input data",
-            "content": {
-              "application/json": {
-                "example": {
-                  "id": "550e8400-e29b-41d4-a716-446655440000",
-                  "status": {
-                    "code": 2,
-                    "message": "Invalid input"
-                  },
-                  "detail": [
-                    {
-                      "loc": ["body", "prediction_config"],
-                      "msg": "Field required",
-                      "type": "missing"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "Payload Too Large",
-            "content": {
-              "application/json": {
-                "example": {
-                  "id": "550e8400-e29b-41d4-a716-446655440000",
-                  "status": {
-                    "code": 2,
-                    "message": "Invalid input"
-                  },
-                  "detail": [
-                    {
-                      "loc": [],
-                      "msg": "Request body too large (>10485760 bytes)",
-                      "type": "value_error"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "example": {
-                  "id": "550e8400-e29b-41d4-a716-446655440000",
-                  "status": {
-                    "code": 2,
-                    "message": "Invalid input"
-                  },
-                  "detail": [
-                    {
-                      "loc": ["body", "prediction_config"],
-                      "msg": "Field required",
-                      "type": "value_error"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "example": {
-                  "id": "550e8400-e29b-41d4-a716-446655440000",
-                  "status": {
-                    "code": 3,
-                    "message": "Internal server error"
-                  },
-                  "detail": []
-                }
-              }
+        "parameters": [
+          {
+            "name": "Content-Encoding",
+            "in": "header",
+            "description": "Content encoding of the request body. Use 'gzip' for gzip-compressed payloads. Use compression level 1.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["gzip"]
             }
           }
-        }
+        ]
       }
     },
     "/predict_parquet": {
       "post": {
-        "summary": "Make in-context predictions for specified target columns based on provided table data Parquet file.",
-        "description": "Make in-context predictions for specified target columns based on provided table data Parquet file.",
+        "summary": "Make predictions from Parquet file",
         "operationId": "predict_parquet",
         "requestBody": {
           "content": {
@@ -315,7 +372,8 @@
                       ],
                       "PRICE": [
                         {
-                          "prediction": 195.090179443359
+                          "prediction": 195.09017944335938,
+                          "confidence_interval": [191.4201023, 198.7602565]
                         }
                       ],
                       "ID": "35"
@@ -329,12 +387,29 @@
                       ],
                       "PRICE": [
                         {
-                          "prediction": 209.380523681641
+                          "prediction": 209.38052368164062,
+                          "confidence_interval": [198.182501013, 220.57854635]
                         }
                       ],
                       "ID": "104"
                     }
                   ],
+                  "explanations": {
+                    "top_column_scores": [
+                      {
+                        "PRODUCT": 0.08,
+                        "ORDERDATE": 0.03
+                      },
+                      {
+                        "PRODUCT": 0.07,
+                        "ORDERDATE": 0.02
+                      }
+                    ],
+                    "top_relevant_context_rows": [
+                      [3, 4, 1],
+                      [2, 1, 4]
+                    ]
+                  },
                   "metadata": {
                     "num_columns": 5,
                     "num_rows": 2,
@@ -422,6 +497,21 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "550e8400-e29b-41d4-a716-446655440000",
+                  "status": {
+                    "code": 4,
+                    "message": "Server under high load, please try again later"
+                  },
+                  "detail": []
+                }
+              }
+            }
           }
         }
       }
@@ -433,30 +523,75 @@
         "properties": {
           "file": {
             "type": "string",
-            "format": "binary",
-            "title": "File",
-            "description": "Parquet file containing the data"
+            "contentMediaType": "application/vnd.apache.parquet",
+            "title": "File"
           },
           "prediction_config": {
-            "$ref": "#/components/schemas/PredictionConfig",
+            "type": "string",
             "title": "Prediction Config",
-            "description": "JSON string for prediction_config"
+            "description": "JSON string containing the prediction configuration (see PredictionConfig schema).",
+            "example": "{\"target_columns\":[{\"name\": \"PRICE\",\"prediction_placeholder\": null,\"task_type\": \"regression\"}]}",
+            "contentMediaType": "application/json",
+            "contentSchema": {
+              "$ref": "#/components/schemas/PredictionConfig"
+            }
           },
           "index_column": {
             "type": "string",
-            "title": "Index Column",
-            "description": "Optional index column name"
+            "title": "Index Column"
           },
           "parse_data_types": {
             "type": "boolean",
             "title": "Parse Data Types",
-            "description": "Whether to parse data types",
-            "default": true
+            "default": false
           }
         },
         "type": "object",
         "required": ["file", "prediction_config"],
         "title": "Body_predict_parquet"
+      },
+      "ExplanationResult": {
+        "properties": {
+          "top_column_scores": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": {
+                    "type": "number"
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top Column Scores",
+            "description": "Column scores per query row extracted from the model (higher means more weight was put on this column)."
+          },
+          "top_relevant_context_rows": {
+            "anyOf": [
+              {
+                "items": {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top Relevant Context Rows",
+            "description": "2D array where each subarray contains indices of most relevant context rows for that query row. The first dimension indexes query rows, the second dimension indexes all rows as a sequential integer index."
+          }
+        },
+        "type": "object",
+        "title": "ExplanationResult",
+        "description": "Explanation data for predictions."
       },
       "PredictResponseMetadata": {
         "properties": {
@@ -526,6 +661,17 @@
             "title": "Predictions",
             "description": "Mapping of column names to their list of prediction results or index column."
           },
+          "explanations": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ExplanationResult"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Explanation data containing context row and column scores."
+          },
           "metadata": {
             "$ref": "#/components/schemas/PredictResponseMetadata"
           }
@@ -541,7 +687,7 @@
           "code": {
             "type": "integer",
             "title": "Code",
-            "description": "Status code (zero means success, other status codes indicate warnings)"
+            "description": "Status code (zero means success, other status codes indicate warnings or errors)"
           },
           "message": {
             "type": "string",
@@ -566,19 +712,43 @@
               }
             ],
             "title": "Prediction",
-            "description": "The predicted value for the column."
+            "description": "The predicted value for the column (string for classification, number for regression)."
           },
           "confidence": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
               },
               {
                 "type": "null"
               }
             ],
             "title": "Confidence",
-            "description": "The confidence of the prediction (currently not provided)."
+            "description": "The confidence of the prediction (null for regression predictions)."
+          },
+          "confidence_interval": {
+            "anyOf": [
+              {
+                "prefixItems": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ],
+                "type": "array",
+                "maxItems": 2,
+                "minItems": 2
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Interval",
+            "description": "Lower and upper bounds of the prediction confidence interval (null for classification predictions)."
           }
         },
         "additionalProperties": true,
@@ -588,9 +758,51 @@
         "description": "A single prediction result for a single column in a single row."
       },
       "ColumnType": {
-        "enum": ["string", "numeric", "date"],
+        "description": "Supported column data types for the data schema.\n\nIncludes base types (string, numeric, date) and additional types\nderived from SAP CDS (https://cap.cloud.sap/docs/cds/types#core-built-in-types).\nAdditional types are mapped to the corresponding base type internally.\nAll values are lowercase for case-insensitive matching.",
+        "enum": [
+          "string",
+          "numeric",
+          "date",
+          "boolean",
+          "largestring",
+          "uuid",
+          "integer",
+          "int16",
+          "int32",
+          "int64",
+          "uint8",
+          "decimal",
+          "double",
+          "time",
+          "datetime",
+          "timestamp"
+        ],
         "title": "ColumnType",
         "type": "string"
+      },
+      "ExplanationConfig": {
+        "additionalProperties": false,
+        "description": "Configuration for explainability outputs.",
+        "properties": {
+          "top_column_scores": {
+            "default": 0,
+            "description": "For how many columns to output column scores (optional, default is 0). 0 by default (no explainability). Max value is 20.",
+            "maximum": 20,
+            "minimum": 0,
+            "title": "Top Column Scores",
+            "type": "integer"
+          },
+          "top_relevant_context_rows": {
+            "default": 0,
+            "description": "For how many context rows to return indices per query row (optional, default is 0). 0 by default (no explainability). Max value is 20.",
+            "maximum": 20,
+            "minimum": 0,
+            "title": "Top Relevant Context Rows",
+            "type": "integer"
+          }
+        },
+        "title": "ExplanationConfig",
+        "type": "object"
       },
       "PredictionConfig": {
         "additionalProperties": false,
@@ -602,6 +814,10 @@
             },
             "title": "Target Columns",
             "type": "array"
+          },
+          "explanations": {
+            "$ref": "#/components/schemas/ExplanationConfig",
+            "description": "Optional configuration for explainability outputs (column scores and relevant context rows)."
           }
         },
         "required": ["target_columns"],
@@ -609,11 +825,12 @@
         "type": "object"
       },
       "SchemaFieldConfig": {
+        "additionalProperties": false,
         "description": "Configuration for a single field in the input data schema.",
         "properties": {
           "dtype": {
             "$ref": "#/components/schemas/ColumnType",
-            "description": "The data type of the target column. Supported types are ['string', 'numeric', 'date']."
+            "description": "The data type of the column. Supports base types (string, numeric, date) and extended types (e.g., Boolean, Integer, Timestamp). Extended types are mapped to corresponding base types internally. Case-insensitive."
           }
         },
         "required": ["dtype"],
@@ -621,6 +838,7 @@
         "type": "object"
       },
       "TargetColumnConfig": {
+        "additionalProperties": false,
         "description": "Configuration for a target column in the prediction model.",
         "properties": {
           "name": {
@@ -635,6 +853,9 @@
               },
               {
                 "type": "number"
+              },
+              {
+                "type": "null"
               }
             ],
             "description": "The placeholder value in any column for which to predict a value. The model will predict a value for all table cells containing this value.",
@@ -664,7 +885,7 @@
               }
             ],
             "default": null,
-            "description": "How many predictions to output per classification column.If not provided, only a single prediction is returned. Only relevant for classification.",
+            "description": "How many predictions to output for this classification column.If not provided, only a single prediction is returned. Only relevant for classification.",
             "title": "Top K"
           }
         },
@@ -673,41 +894,122 @@
         "type": "object"
       },
       "PredictRequestPayload": {
-        "additionalProperties": false,
-        "description": "Users need to specify a list of rows, which contains both the context rows\nand the rows for which to predict a label, and a mapping of column names\nto placeholder values. The model will predict the value for any column\nspecified in `predict_columns` for all rows that have the placeholder\nvalue in that column.",
-        "properties": {
-          "prediction_config": {
-            "$ref": "#/components/schemas/PredictionConfig",
-            "description": "Configuration of target columns and placeholder value."
-          },
-          "rows": {
-            "default": null,
-            "description": "Table rows, i.e. list of objects where each object is a mapping of column names to values. Either \"rows\" or \"columns\" must be provided.",
-            "items": {
-              "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "prediction_config": {
+                "$ref": "#/components/schemas/PredictionConfig",
+                "description": "Configuration of target columns and placeholder value."
+              },
+              "index_column": {
                 "anyOf": [
                   {
                     "type": "string"
                   },
                   {
-                    "type": "number"
-                  },
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "The name of the index column. If provided, the service will return this column's value in each prediction object to facilitate aligning the output predictions with the input rows on the client side. If not provided, the column will not be included in the output.",
+                "title": "Index Column"
+              },
+              "parse_data_types": {
+                "default": true,
+                "description": "Whether to parse the data types of the columns. If set to True, numeric columns will be parsed to float or integer and dates in ISO format YYYY-MM-DD will be parsed.",
+                "title": "Parse Data Types",
+                "type": "boolean"
+              },
+              "data_schema": {
+                "anyOf": [
                   {
-                    "type": "integer"
+                    "additionalProperties": {
+                      "$ref": "#/components/schemas/SchemaFieldConfig"
+                    },
+                    "type": "object"
                   },
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "default": null,
+                "description": "Optional schema defining the data types of each column. If provided, this will override automatic data type parsing.",
+                "title": "Data Schema"
               },
-              "type": "object"
+              "rows": {
+                "description": "Table rows, i.e. list of objects where each object is a mapping of column names to values. Either \"rows\" or \"columns\" must be provided.",
+                "items": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                "title": "Rows",
+                "type": "array"
+              }
             },
-            "title": "Rows",
-            "type": "array"
+            "required": ["prediction_config", "rows"],
+            "additionalProperties": false
           },
-          "columns": {
-            "anyOf": [
-              {
+          {
+            "type": "object",
+            "properties": {
+              "prediction_config": {
+                "$ref": "#/components/schemas/PredictionConfig",
+                "description": "Configuration of target columns and placeholder value."
+              },
+              "index_column": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "The name of the index column. If provided, the service will return this column's value in each prediction object to facilitate aligning the output predictions with the input rows on the client side. If not provided, the column will not be included in the output.",
+                "title": "Index Column"
+              },
+              "parse_data_types": {
+                "default": true,
+                "description": "Whether to parse the data types of the columns. If set to True, numeric columns will be parsed to float or integer and dates in ISO format YYYY-MM-DD will be parsed.",
+                "title": "Parse Data Types",
+                "type": "boolean"
+              },
+              "data_schema": {
+                "anyOf": [
+                  {
+                    "additionalProperties": {
+                      "$ref": "#/components/schemas/SchemaFieldConfig"
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Optional schema defining the data types of each column. If provided, this will override automatic data type parsing.",
+                "title": "Data Schema"
+              },
+              "columns": {
+                "description": "Alternative to rows: columns of data where each key is a column name and the value is a list of all column values. Either \"rows\" or \"columns\" must be provided.",
+                "title": "Columns",
                 "additionalProperties": {
                   "items": {
                     "anyOf": [
@@ -728,54 +1030,13 @@
                   "type": "array"
                 },
                 "type": "object"
-              },
-              {
-                "type": "null"
               }
-            ],
-            "default": null,
-            "description": "Alternative to rows: columns of data where each key is a column name and the value is a list of all column values. Either \"rows\" or \"columns\" must be provided.",
-            "title": "Columns"
-          },
-          "index_column": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "The name of the index column. If provided, the service will return this column's value in each prediction object to facilitate aligning the output predictions with the input rows on the client side. If not provided, the column will not be included in the output.",
-            "title": "Index Column"
-          },
-          "parse_data_types": {
-            "default": true,
-            "description": "Whether to parse the data types of the columns. If set to True, numeric columns will be parsed to float or integer and dates in ISO format YYYY-MM-DD will be parsed.",
-            "title": "Parse Data Types",
-            "type": "boolean"
-          },
-          "data_schema": {
-            "anyOf": [
-              {
-                "additionalProperties": {
-                  "$ref": "#/components/schemas/SchemaFieldConfig"
-                },
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Optional schema defining the data types of each column. If provided, this will override automatic data type parsing.",
-            "title": "Data Schema"
+            },
+            "required": ["prediction_config", "columns"],
+            "additionalProperties": false
           }
-        },
-        "required": ["prediction_config"],
-        "title": "PredictRequestPayload",
-        "type": "object"
+        ],
+        "description": "Users need to specify a list of rows, which contains both the context rows and the rows for which to predict a label, and a mapping of column names to placeholder values. The model will predict the value for any column specified in `target_columns` for all rows that have the prediction placeholder in that column. Either \"rows\" or \"columns\" must be provided, but not both."
       }
     }
   },

--- a/packages/rpt/src/types.ts
+++ b/packages/rpt/src/types.ts
@@ -31,8 +31,8 @@ export type DateString =
 type TsType<T extends ColType> = T extends 'numeric'
   ? number
   : T extends 'date'
-    ? DateString
-    : string;
+  ? DateString
+  : string;
 
 /**
  * Represents the type of the `rows` property.
@@ -42,10 +42,10 @@ type TsType<T extends ColType> = T extends 'numeric'
  */
 export type RowType<T extends DataSchema> = T extends readonly any[]
   ? {
-      [N in T[number]['name']]: TsType<
-        Extract<T[number], { name: N }>['dtype']
-      >;
-    }
+    [N in T[number]['name']]: TsType<
+      Extract<T[number], { name: N }>['dtype']
+    >;
+  }
   : Record<string, string | number>;
 
 /**
@@ -128,7 +128,7 @@ export type PredictionData<T extends DataSchema> = {
 /**
  * Representation of the payload for Parquet-based predictions.
  */
-export type ParquetPayload = BodyPredictParquet & {
+export type ParquetPayload = Omit<BodyPredictParquet, 'prediction_config'> & {
   /**
    * Parquet file containing the data. Can also be a File to forward the filename.
    */

--- a/packages/rpt/src/types.ts
+++ b/packages/rpt/src/types.ts
@@ -31,8 +31,8 @@ export type DateString =
 type TsType<T extends ColType> = T extends 'numeric'
   ? number
   : T extends 'date'
-  ? DateString
-  : string;
+    ? DateString
+    : string;
 
 /**
  * Represents the type of the `rows` property.
@@ -42,10 +42,10 @@ type TsType<T extends ColType> = T extends 'numeric'
  */
 export type RowType<T extends DataSchema> = T extends readonly any[]
   ? {
-    [N in T[number]['name']]: TsType<
-      Extract<T[number], { name: N }>['dtype']
-    >;
-  }
+      [N in T[number]['name']]: TsType<
+        Extract<T[number], { name: N }>['dtype']
+      >;
+    }
   : Record<string, string | number>;
 
 /**

--- a/sample-code/src/rpt.ts
+++ b/sample-code/src/rpt.ts
@@ -63,7 +63,7 @@ const data: PredictionData<typeof schema> = {
  * @returns The prediction results.
  */
 export async function predictWithSchema(): Promise<PredictResponsePayload> {
-  const client = new RptClient();
+  const client = new RptClient('sap-rpt-1.5');
   return client.predictWithSchema(schema, data);
 }
 
@@ -72,7 +72,7 @@ export async function predictWithSchema(): Promise<PredictResponsePayload> {
  * @returns The prediction results.
  */
 export async function predictWithSchemaCompressed(): Promise<PredictResponsePayload> {
-  const client = new RptClient();
+  const client = new RptClient('sap-rpt-1.5');
   return client.predictWithSchema(schema, data, {
     compress: {
       mode: 'always' // force-enable compression
@@ -85,7 +85,7 @@ export async function predictWithSchemaCompressed(): Promise<PredictResponsePayl
  * @returns The prediction results.
  */
 export async function predictAutomaticParsing(): Promise<PredictResponsePayload> {
-  const client = new RptClient();
+  const client = new RptClient('sap-rpt-1.5');
   return client.predictWithoutSchema(data);
 }
 
@@ -107,7 +107,7 @@ export async function predictParquetFile(): Promise<PredictResponsePayload> {
     type: 'application/vnd.apache.parquet'
   });
   // Send the Parquet file to the RPT service for predictions
-  const client = new RptClient();
+  const client = new RptClient('sap-rpt-1.5');
   return client.predictParquet({
     file: parquetFile,
     prediction_config: data.prediction_config,
@@ -125,7 +125,7 @@ export async function predictParquetBlob(): Promise<PredictResponsePayload> {
     type: 'application/vnd.apache.parquet'
   });
   // Send the Parquet blob to the RPT service for predictions
-  const client = new RptClient();
+  const client = new RptClient('sap-rpt-1.5');
   return client.predictParquet({
     file: parquetFileBlob,
     prediction_config: data.prediction_config,
@@ -140,7 +140,7 @@ export async function predictParquetBlob(): Promise<PredictResponsePayload> {
  * @returns The prediction results.
  */
 export async function predictWithSchemaResilient(): Promise<PredictResponsePayload> {
-  const client = new RptClient();
+  const client = new RptClient('sap-rpt-1.5');
   return client.predictWithSchema(schema, data, {
     middleware: resilience({ timeout: 30000, circuitBreaker: true, retry: 1 })
   });


### PR DESCRIPTION
Try out rpt 1.5 spec. 

Key findings:

The spec contains OAS 3.1 features. Meaning the new openapi-generator in the soon released Cloud SDK JS 4.9.0 is needed.

One noticeable breaking change (for SDK, not necessarily for our users) and "weird behaviour":

```json
        "prediction_config": {
            "type": "string",
            "title": "Prediction Config",
            "description": "JSON string containing the prediction configuration (see PredictionConfig schema).",
            "example": "{\"target_columns\":[{\"name\": \"PRICE\",\"prediction_placeholder\": null,\"task_type\": \"regression\"}]}",
            "contentMediaType": "application/json",
            "contentSchema": {
              "$ref": "#/components/schemas/PredictionConfig"
            }
          },
```

In the rpt 1.5 spec, `prediction_config` now has type `string`. I tried it out and the remote server accepts both JSON string and JSON object. It is questionable if they should change the type to oneOf `string` or `PredictionConfig` ref.

This is currently causing issues in our SDK as we need to then either JSON parse the object before sending it to remote, or just mark the object type as any as the remote reads object as well.

Other changes are mostly feature additions. We need to think if we

- have two separate packages (feels overkill to me)
- have two separate clients (okay)
- or have one client but do type inference based on the model deployment name (but how do we know at design time whether we should show rpt 1.5 specific types if user provides directly deployment id? Also this approach is quite complicated by mixing two specs with the assumption that they won't diverge significantly)