### PR TITLE
chore: use branch lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist
 dist-cjs
 node_modules
+pnpm-lock.*.yaml
 coverage
 
 # Logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 dist
 dist-cjs
 node_modules
-pnpm-lock.*.yaml
 coverage
 
 # Logs

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,10 @@ allowBuilds:
   esbuild: false
   unrs-resolver: false
 
+gitBranchLockfile: true
+mergeGitBranchLockfilesBranchPattern:
+  - main
+
 blockExoticSubdeps: true
 minimumReleaseAge: 5760
 minimumReleaseAgeExclude:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ allowBuilds:
 gitBranchLockfile: true
 mergeGitBranchLockfilesBranchPattern:
   - main
+  - renovate/*
 
 blockExoticSubdeps: true
 minimumReleaseAge: 5760


### PR DESCRIPTION
While researching solutions to the pnpm merge conflicts we have, I found this: https://pnpm.io/git_branch_lockfiles

I would like to propose trying it out for a while and keep this setting if it doesn't cause problems.