### PR TITLE
fix(core): set 1.201s default HTTP agent timeout, disable keep-alive for AI Core requests

### DIFF
--- a/.changeset/default-agent-timeout.md
+++ b/.changeset/default-agent-timeout.md
@@ -2,8 +2,9 @@
 '@sap-ai-sdk/core': patch
 ---
 
-[fix] Set the default http agent socket timeout for AI Core requests to 12 minutes (720000 ms).
+[fix] Set the default http agent socket timeout for AI Core requests to 1201 seconds (1201000 ms).
 This overrides the Cloud SDK default of 5 seconds, which is too short for chat and streaming completions.
+The value covers the orchestration server-side maximum of 1200 seconds plus 1 second of leeway.
 Keep-alive is now disabled on these requests.
 This avoids reusing stale sockets that a load balancer may have closed during the longer timeout.
 Both settings apply only to the service-binding destination.

--- a/.changeset/default-agent-timeout.md
+++ b/.changeset/default-agent-timeout.md
@@ -1,0 +1,10 @@
+---
+'@sap-ai-sdk/core': patch
+---
+
+[fix] Set the default http agent socket timeout for AI Core requests to 12 minutes (720000 ms).
+This overrides the Cloud SDK default of 5 seconds, which is too short for chat and streaming completions.
+Keep-alive is now disabled on these requests.
+This avoids reusing stale sockets that a load balancer may have closed during the longer timeout.
+Both settings apply only to the service-binding destination.
+You can still override them with a custom destination's `agentOptions` or `CustomRequestConfig.httpsAgent`.

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -1,7 +1,26 @@
+import { transformServiceBindingToDestination } from '@sap-cloud-sdk/connectivity';
+
 import nock from 'nock';
+import { vi } from 'vitest';
 
 import { mockClientCredentialsGrantCall } from '../../../test-util/mock-http.ts';
 import { getAiCoreDestination } from './context.ts';
+
+import type * as Connectivity from '@sap-cloud-sdk/connectivity';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
+
+// Keep the real Cloud SDK implementation by default (so the OAuth-failure test
+// below still exercises the real transform + nock flow), but make
+// transformServiceBindingToDestination overridable per test via mockResolvedValueOnce.
+vi.mock('@sap-cloud-sdk/connectivity', async importOriginal => {
+  const actual = await importOriginal<typeof Connectivity>();
+  return {
+    ...actual,
+    transformServiceBindingToDestination: vi.fn(
+      actual.transformServiceBindingToDestination
+    )
+  };
+});
 
 describe('context', () => {
   afterAll(() => {
@@ -19,5 +38,47 @@ describe('context', () => {
     await expect(getAiCoreDestination()).rejects.toThrow(
       /Could not fetch client credentials token for service of type "aicore"/
     );
+  });
+
+  it('should inject the default agent timeout for a client-secret service binding', async () => {
+    mockClientCredentialsGrantCall();
+    const destination = await getAiCoreDestination();
+    expect(destination.agentOptions?.timeout).toBe(720000);
+    // Keep-alive is disabled to avoid stale-socket reuse with the long timeout.
+    expect(destination.agentOptions?.keepAlive).toBe(false);
+  });
+
+  // Note: this mocks transformServiceBindingToDestination, so it verifies the
+  // timeout injection on an mTLS-shaped destination, not the real Cloud SDK mTLS
+  // transform path (which is verified by reading the shared merge logic).
+  it('should inject the default agent timeout on an mTLS-shaped destination', async () => {
+    vi.mocked(transformServiceBindingToDestination).mockResolvedValueOnce({
+      url: 'https://api.ai.ml.hana.ondemand.com',
+      authentication: 'ClientCertificateAuthentication',
+      mtlsKeyPair: { cert: 'cert', key: 'key' }
+    } as HttpDestination);
+    const destination = await getAiCoreDestination();
+    expect(destination.agentOptions?.timeout).toBe(720000);
+  });
+
+  it('should return a user-provided destination unchanged without injecting agentOptions', async () => {
+    const userDestination: HttpDestination = {
+      url: 'https://user.example.com',
+      authentication: 'NoAuthentication'
+    };
+    const destination = await getAiCoreDestination(userDestination);
+    expect(destination.agentOptions).toBeUndefined();
+  });
+
+  it('should not overwrite pre-existing agent options on the service-binding destination', async () => {
+    vi.mocked(transformServiceBindingToDestination).mockResolvedValueOnce({
+      url: 'https://api.ai.ml.hana.ondemand.com',
+      authentication: 'OAuth2ClientCredentials',
+      agentOptions: { timeout: 60000, keepAlive: true }
+    } as HttpDestination);
+    const destination = await getAiCoreDestination();
+    // A destination that already carries agentOptions wins over the injected defaults.
+    expect(destination.agentOptions?.timeout).toBe(60000);
+    expect(destination.agentOptions?.keepAlive).toBe(true);
   });
 });

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -43,7 +43,7 @@ describe('context', () => {
   it('should inject the default agent timeout for a client-secret service binding', async () => {
     mockClientCredentialsGrantCall();
     const destination = await getAiCoreDestination();
-    expect(destination.agentOptions?.timeout).toBe(720000);
+    expect(destination.agentOptions?.timeout).toBe(1201000);
     // Keep-alive is disabled to avoid stale-socket reuse with the long timeout.
     expect(destination.agentOptions?.keepAlive).toBe(false);
   });
@@ -58,7 +58,7 @@ describe('context', () => {
       mtlsKeyPair: { cert: 'cert', key: 'key' }
     } as HttpDestination);
     const destination = await getAiCoreDestination();
-    expect(destination.agentOptions?.timeout).toBe(720000);
+    expect(destination.agentOptions?.timeout).toBe(1201000);
   });
 
   it('should return a user-provided destination unchanged without injecting agentOptions', async () => {

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -18,9 +18,9 @@ const logger = createLogger({
   messageContext: 'context'
 });
 
-// Default HTTP agent socket timeout for AI Core requests (12 min), overriding the
+// Default HTTP agent socket timeout for AI Core requests (1,200s + 1s leeway), overriding the
 // Cloud SDK default of 5s, which is too short for chat/streaming completions.
-const DEFAULT_AGENT_TIMEOUT = 720_000;
+const DEFAULT_AGENT_TIMEOUT = 1_200_000 + 1e3;
 
 // Disabled so the long timeout above does not keep stale pooled sockets alive past
 // a load balancer's idle timeout, which would cause ECONNRESET on reuse.

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -23,7 +23,9 @@ const logger = createLogger({
 const DEFAULT_AGENT_TIMEOUT = 1_200_000 + 1e3;
 
 // Disabled so the long timeout above does not keep stale pooled sockets alive past
-// a load balancer's idle timeout, which would cause ECONNRESET on reuse.
+// a load balancer's idle timeout, which would cause ECONNRESET on reuse. Revisit if
+// we switch HTTP library (e.g. undici / a fetch adapter), which can isolate the idle
+// free-socket timeout from the active-request timeout and make keep-alive safe here.
 const DEFAULT_AGENT_KEEP_ALIVE = false;
 
 let aiCoreServiceBinding: Service | undefined;

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -23,9 +23,10 @@ const logger = createLogger({
 const DEFAULT_AGENT_TIMEOUT = 1_200_000 + 1e3;
 
 // Disabled so the long timeout above does not keep stale pooled sockets alive past
-// a load balancer's idle timeout, which would cause ECONNRESET on reuse. Revisit if
-// we switch HTTP library (e.g. undici / a fetch adapter), which can isolate the idle
-// free-socket timeout from the active-request timeout and make keep-alive safe here.
+// a load balancer's idle timeout, which would cause ECONNRESET on reuse.
+// TODO: revisit if we switch HTTP library (e.g. undici / a fetch adapter), which can
+// isolate the idle free-socket timeout from the active-request timeout and make
+// keep-alive safe here.
 const DEFAULT_AGENT_KEEP_ALIVE = false;
 
 let aiCoreServiceBinding: Service | undefined;

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -18,6 +18,14 @@ const logger = createLogger({
   messageContext: 'context'
 });
 
+// Default HTTP agent socket timeout for AI Core requests (12 min), overriding the
+// Cloud SDK default of 5s, which is too short for chat/streaming completions.
+const DEFAULT_AGENT_TIMEOUT = 720_000;
+
+// Disabled so the long timeout above does not keep stale pooled sockets alive past
+// a load balancer's idle timeout, which would cause ECONNRESET on reuse.
+const DEFAULT_AGENT_KEEP_ALIVE = false;
+
 let aiCoreServiceBinding: Service | undefined;
 
 /**
@@ -63,7 +71,14 @@ export async function getAiCoreDestination(
       useCache: true
     }
   )) as HttpDestination;
-  return aiCoreDestination;
+  return {
+    ...aiCoreDestination,
+    agentOptions: {
+      keepAlive: DEFAULT_AGENT_KEEP_ALIVE,
+      timeout: DEFAULT_AGENT_TIMEOUT,
+      ...aiCoreDestination.agentOptions
+    }
+  };
 }
 
 function getAiCoreServiceKeyFromEnv(): Service | undefined {

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -114,7 +114,12 @@ function mergeWithDefaultRequestConfig(
       'content-type': 'application/json',
       'ai-resource-group': resourceGroup
     },
-    params: apiVersion ? { 'api-version': apiVersion } : {}
+    params: apiVersion ? { 'api-version': apiVersion } : {},
+    // Do not cap request/response size for AI Core: prompts and completions can be
+    // large. No-op on the current http adapter (axios defaults both to -1 = unlimited),
+    // but keeps the intent explicit and safe under a fetch adapter.
+    maxContentLength: Number.POSITIVE_INFINITY,
+    maxBodyLength: Number.POSITIVE_INFINITY
   };
 
   const mergedHeaders = mergeIgnoreCase(


### PR DESCRIPTION
## Context

Closes SAP/ai-sdk-js-backlog#623.

## What this PR does and why it is needed

The SDK inherited the SAP Cloud SDK's 5s HTTP socket timeout, which is too short for long-running chat and streaming completions. This PR sets a 12-minute (720000 ms) default socket timeout on the service-binding-derived AI Core destination (covering both client-secret and mTLS auth).

Keep-alive is disabled on these requests: with the old 5s timeout, idle pooled sockets were evicted before any load balancer closed them; the longer timeout would otherwise keep stale sockets around long enough to be reused and trigger ECONNRESET. Disabling pooling avoids stale-socket reuse while the long timeout still covers slow responses. Rationale and the researched load-balancer idle timeouts are in the decision record.

Both defaults apply only to the SDK-managed destination and can be overridden via a custom destination's `agentOptions` or per-request `CustomRequestConfig.httpsAgent`.

**Open for reviewers:** confirm disabling keep-alive is acceptable vs. adding `agentkeepalive` to preserve pooling (would need SAP BTP's actual LB idle timeout to tune). Docs handled in a separate SAP/ai-sdk PR — link to follow.

## Definition of Done

- [x] Code is tested (Unit, E2E)
- [ ] Error handling created / updated & covered by the tests above
- [x] Documentation updated
  - Only Public APIs are allowed to be used in documentation/tutorials/sample code
- [ ] (Optional) Aligned changes with the Java SDK
- [ ] (Optional) Release notes updated